### PR TITLE
fix qweather forecast display issues

### DIFF
--- a/contents/ui/ForecastView.qml
+++ b/contents/ui/ForecastView.qml
@@ -383,6 +383,38 @@ Item {
                         return [];
                     }
 
+                    readonly property string _daySunriseText: {
+                        if (weatherRoot && weatherRoot.dailyData[dataIndex] && weatherRoot.dailyData[dataIndex].sunriseTimeText)
+                            return weatherRoot.dailyData[dataIndex].sunriseTimeText;
+                        return weatherRoot ? weatherRoot.sunriseTimeText : "--";
+                    }
+
+                    readonly property string _daySunsetText: {
+                        if (weatherRoot && weatherRoot.dailyData[dataIndex] && weatherRoot.dailyData[dataIndex].sunsetTimeText)
+                            return weatherRoot.dailyData[dataIndex].sunsetTimeText;
+                        return weatherRoot ? weatherRoot.sunsetTimeText : "--";
+                    }
+
+                    readonly property bool _dayOutsideQWeatherHourlyRange: {
+                        if ((Plasmoid.configuration.weatherProvider || "adaptive") !== "qWeather")
+                            return false;
+                        var ds = (weatherRoot && weatherRoot.dailyData[dataIndex])
+                            ? (weatherRoot.dailyData[dataIndex].dateStr || "") : "";
+                        if (!ds)
+                            return false;
+                        var parts = ds.split("-");
+                        if (parts.length < 3)
+                            return false;
+                        var year = parseInt(parts[0], 10);
+                        var month = parseInt(parts[1], 10) - 1;
+                        var day = parseInt(parts[2], 10);
+                        if (isNaN(year) || isNaN(month) || isNaN(day))
+                            return false;
+                        var dayStartMs = new Date(year, month, day, 0, 0, 0, 0).getTime();
+                        var hourlyLimitMs = (new Date()).getTime() + 168 * 3600 * 1000;
+                        return dayStartMs >= hourlyLimitMs;
+                    }
+
                     readonly property bool _dayIsLoading: {
                         var dateStr = (weatherRoot && weatherRoot.dailyData[dataIndex])
                             ? (weatherRoot.dailyData[dataIndex].dateStr || "") : "";
@@ -771,10 +803,15 @@ Item {
                         // Plain loading text for single-expand mode
                         Label {
                             anchors.centerIn: parent
+                            width: parent.width - 24
                             visible: !_dayIsLoading && ((forecastRoot.expandAll && !forecastRoot._collapsedDays[weatherRoot.dailyData[dataIndex].dateStr || ""]) || forecastRoot.expandedIndex === index) && _dayHourlyData.length === 0
-                            text: i18n("Loading hourly data…")
+                            text: _dayOutsideQWeatherHourlyRange
+                                ? i18n("QWeather provides hourly forecasts for up to 168 hours (7 days). Daily forecast is still available for this date.")
+                                : i18n("Loading hourly data…")
                             color: Kirigami.Theme.textColor
                             font: weatherRoot ? weatherRoot.wf(11, false) : Qt.font({})
+                            wrapMode: Text.Wrap
+                            horizontalAlignment: Text.AlignHCenter
                         }
 
                         // Only instantiate the heavy hourly UI for the expanded day.
@@ -842,8 +879,8 @@ Item {
                                             : _dayHourlyData;
                                         if (!forecastRoot.showSunEvents)
                                             return source;
-                                        var rise = toMins(weatherRoot.sunriseTimeText);
-                                        var set_ = toMins(weatherRoot.sunsetTimeText);
+                                        var rise = toMins(_daySunriseText);
+                                        var set_ = toMins(_daySunsetText);
                                         // Only insert sun markers if they are still in the future (for today)
                                         var riseInserted = rise < 0 || (nowMins >= 0 && rise < nowMins);
                                         var setInserted  = set_  < 0 || (nowMins >= 0 && set_  < nowMins);
@@ -851,11 +888,11 @@ Item {
                                         source.forEach(function(h) {
                                             var hm = toMins(h.hour);
                                             if (!riseInserted && hm >= 0 && hm > rise) {
-                                                result.push({ isSunrise: true, isSunset: false, time: weatherRoot.sunriseTimeText });
+                                                result.push({ isSunrise: true, isSunset: false, time: _daySunriseText });
                                                 riseInserted = true;
                                             }
                                             if (!setInserted && hm >= 0 && hm > set_) {
-                                                result.push({ isSunrise: false, isSunset: true, time: weatherRoot.sunsetTimeText });
+                                                result.push({ isSunrise: false, isSunset: true, time: _daySunsetText });
                                                 setInserted = true;
                                             }
                                             result.push(h);
@@ -942,8 +979,8 @@ Item {
                                                                 if (p2.length >= 2) {
                                                                     var hm2 = parseInt(p2[0],10)*60+parseInt(p2[1],10);
                                                                     function _sm(t) { if (!t||t==="--") return -1; var p=t.split(":"); return p.length<2?-1:parseInt(p[0],10)*60+parseInt(p[1],10); }
-                                                                    var rise2=_sm(weatherRoot?weatherRoot.sunriseTimeText:"--");
-                                                                    var set2=_sm(weatherRoot?weatherRoot.sunsetTimeText:"--");
+                                                                    var rise2=_sm(_daySunriseText);
+                                                                    var set2=_sm(_daySunsetText);
                                                                     if (rise2>=0&&set2>=0) isNight=hm2<rise2||hm2>=set2;
                                                                 }
                                                             }
@@ -1419,13 +1456,13 @@ Item {
                                                     closestIdx = i;
                                                 }
                                             }
-                                            if (forecastRoot.showSunEvents && weatherRoot.sunriseTimeText && weatherRoot.sunsetTimeText) {
+                                            if (forecastRoot.showSunEvents && _daySunriseText && _daySunsetText) {
                                                 function toMins(t) {
                                                     if (!t || t === "--") return -1;
                                                     var p = t.split(":"); return p.length < 2 ? -1 : parseInt(p[0],10)*60+parseInt(p[1],10);
                                                 }
-                                                var rise = toMins(weatherRoot.sunriseTimeText);
-                                                var set_ = toMins(weatherRoot.sunsetTimeText);
+                                                var rise = toMins(_daySunriseText);
+                                                var set_ = toMins(_daySunsetText);
                                                 var targetMins = closestIdx < _dayHourlyData.length ? toMins(_dayHourlyData[closestIdx].hour) : -1;
                                                 if (rise >= 0 && targetMins >= 0 && rise < targetMins) closestIdx++;
                                                 if (set_ >= 0 && targetMins >= 0 && set_ < targetMins) closestIdx++;
@@ -1434,13 +1471,13 @@ Item {
                                             var sunWidth = 70;
                                             var spacing = 6;
                                             var scrollPos = 0;
-                                            if (forecastRoot.showSunEvents && weatherRoot.sunriseTimeText && weatherRoot.sunsetTimeText) {
+                                            if (forecastRoot.showSunEvents && _daySunriseText && _daySunsetText) {
                                                 function toMins2(t) {
                                                     if (!t || t === "--") return -1;
                                                     var p = t.split(":"); return p.length < 2 ? -1 : parseInt(p[0],10)*60+parseInt(p[1],10);
                                                 }
-                                                var rise2 = toMins2(weatherRoot.sunriseTimeText);
-                                                var set2 = toMins2(weatherRoot.sunsetTimeText);
+                                                var rise2 = toMins2(_daySunriseText);
+                                                var set2 = toMins2(_daySunsetText);
                                                 for (var j = 0; j < closestIdx; j++) {
                                                     var hm2 = toMins2(_dayHourlyData[j].hour);
                                                     if (rise2 >= 0 && hm2 > rise2) { scrollPos += sunWidth + spacing; rise2 = -1; }
@@ -1493,19 +1530,19 @@ Item {
                                                 : _dayHourlyData;
                                             if (!forecastRoot.showSunEvents)
                                                 return source;
-                                            var rise = toMins(weatherRoot.sunriseTimeText);
-                                            var set_ = toMins(weatherRoot.sunsetTimeText);
+                                            var rise = toMins(_daySunriseText);
+                                            var set_ = toMins(_daySunsetText);
                                             var riseInserted = rise < 0 || (nowMins >= 0 && rise < nowMins);
                                             var setInserted  = set_  < 0 || (nowMins >= 0 && set_  < nowMins);
                                             var result = [];
                                             source.forEach(function(h) {
                                                 var hm = toMins(h.hour);
                                                 if (!riseInserted && hm >= 0 && hm > rise) {
-                                                    result.push({ isSunrise: true,  isSunset: false, time: weatherRoot.sunriseTimeText });
+                                                    result.push({ isSunrise: true,  isSunset: false, time: _daySunriseText });
                                                     riseInserted = true;
                                                 }
                                                 if (!setInserted && hm >= 0 && hm > set_) {
-                                                    result.push({ isSunset: true,  isSunrise: false, time: weatherRoot.sunsetTimeText });
+                                                    result.push({ isSunset: true,  isSunrise: false, time: _daySunsetText });
                                                     setInserted = true;
                                                 }
                                                 result.push(h);
@@ -1595,8 +1632,8 @@ Item {
                                                                         var p = t.split(":");
                                                                         return p.length < 2 ? -1 : parseInt(p[0], 10) * 60 + parseInt(p[1], 10);
                                                                     }
-                                                                    var rise = parseSunMins(weatherRoot ? weatherRoot.sunriseTimeText : "--");
-                                                                    var set_ = parseSunMins(weatherRoot ? weatherRoot.sunsetTimeText : "--");
+                                                                    var rise = parseSunMins(_daySunriseText);
+                                                                    var set_ = parseSunMins(_daySunsetText);
                                                                     if (rise >= 0 && set_ >= 0)
                                                                         isNight = hMins < rise || hMins >= set_;
                                                                 }

--- a/contents/ui/WeatherService.qml
+++ b/contents/ui/WeatherService.qml
@@ -581,7 +581,26 @@ QtObject {
             var key = service._qwKey(); if (!key) { callback([]); return; }
             var base = service._qwHost();
             var loc  = lon.toFixed(2) + "," + lat.toFixed(2);
-            var url  = base + "/v7/weather/24h?location=" + encodeURIComponent(loc) + "&unit=m";
+            function _qwHourlySpanHours(ds) {
+                if (!ds)
+                    return 168;
+                var parts = ds.split("-");
+                if (parts.length < 3)
+                    return 168;
+                var year = parseInt(parts[0], 10);
+                var month = parseInt(parts[1], 10) - 1;
+                var day = parseInt(parts[2], 10);
+                if (isNaN(year) || isNaN(month) || isNaN(day))
+                    return 168;
+                var targetEnd = new Date(year, month, day, 23, 59, 59, 999);
+                var diffHours = Math.ceil((targetEnd.getTime() - (new Date()).getTime()) / 3600000);
+                if (diffHours <= 24)
+                    return 24;
+                if (diffHours <= 72)
+                    return 72;
+                return 168;
+            }
+            var url  = base + "/v7/weather/" + _qwHourlySpanHours(dateStr) + "h?location=" + encodeURIComponent(loc) + "&unit=m";
             var xhr = new XMLHttpRequest(); xhr.open("GET", url);
             xhr.setRequestHeader("X-QW-Api-Key", key);
             xhr.onreadystatechange = function() {
@@ -617,7 +636,7 @@ QtObject {
                             windDeg:    parseFloat(h.wind360),
                             humidity:   parseFloat(h.humidity),
                             precipProb: h.pop !== undefined && h.pop !== null ? parseFloat(h.pop) : NaN,
-                            precipMm:   parseFloat(h.precip) || NaN
+                            precipMm:   h.precip !== undefined && h.precip !== null ? parseFloat(h.precip) : NaN
                         });
                     });
                     callback(arr);

--- a/contents/ui/providers/qWeather.js
+++ b/contents/ui/providers/qWeather.js
@@ -111,6 +111,26 @@ function _forecastSpans(days) {
     return [30, 15, 10, 7, 3];
 }
 
+function _hourlySpanHours(dateStr) {
+    if (!dateStr)
+        return 168;
+    var parts = dateStr.split("-");
+    if (parts.length < 3)
+        return 168;
+    var year = parseInt(parts[0], 10);
+    var month = parseInt(parts[1], 10) - 1;
+    var day = parseInt(parts[2], 10);
+    if (isNaN(year) || isNaN(month) || isNaN(day))
+        return 168;
+    var targetEnd = new Date(year, month, day, 23, 59, 59, 999);
+    var diffHours = Math.ceil((targetEnd.getTime() - (new Date()).getTime()) / 3600000);
+    if (diffHours <= 24)
+        return 24;
+    if (diffHours <= 72)
+        return 72;
+    return 168;
+}
+
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
     var r = service.weatherRoot;
@@ -205,7 +225,9 @@ function _fetchDailyAttempt(service, W, key, loc, gen, base, spans, spanIdx) {
                         uvMax: (day.uvIndex !== undefined) ? parseFloat(day.uvIndex) : NaN,
                         precipProb: (day.pop !== undefined) ? parseFloat(day.pop) : NaN,
                         windKmh: (day.windSpeed !== undefined) ? parseFloat(day.windSpeed) : NaN,
-                        windDir: (day.wind360 !== undefined) ? parseFloat(day.wind360) : NaN
+                        windDir: (day.wind360 !== undefined) ? parseFloat(day.wind360) : NaN,
+                        sunriseTimeText: day.sunrise || "--",
+                        sunsetTimeText: day.sunset || "--"
                     });
                 }
                 if (d.daily.length > 0) {
@@ -292,7 +314,7 @@ function fetchHourly(service, W, dateStr) {
     }
     var base = service._qwHost();
     var loc = service.longitude.toFixed(2) + "," + service.latitude.toFixed(2);
-    var url = base + "/v7/weather/24h?location=" + encodeURIComponent(loc)
+    var url = base + "/v7/weather/" + _hourlySpanHours(dateStr) + "h?location=" + encodeURIComponent(loc)
         + "&unit=m";
 
     var req = new XMLHttpRequest();
@@ -316,10 +338,14 @@ function fetchHourly(service, W, dateStr) {
                         tempC: parseFloat(h.temp),
                         code: _qwCodeToWmo(h.icon),
                         windKmh: parseFloat(h.windSpeed),
+                        windDeg: parseFloat(h.wind360),
                         windDir: parseFloat(h.wind360),
+                        humidity: parseFloat(h.humidity),
                         humidityPercent: parseFloat(h.humidity),
                         pressureHpa: parseFloat(h.pressure),
+                        precipMm: parseFloat(h.precip) || 0,
                         precipMmh: parseFloat(h.precip) || 0,
+                        precipProb: (h.pop !== undefined && h.pop !== null) ? parseFloat(h.pop) : NaN,
                         pop: (h.pop !== undefined && h.pop !== null) ? parseFloat(h.pop) : NaN,
                         dewPointC: (h.dew !== undefined && h.dew !== null)
                             ? parseFloat(h.dew)

--- a/contents/ui/providers/qWeather.js
+++ b/contents/ui/providers/qWeather.js
@@ -105,7 +105,7 @@ function _calcDewPoint(T, rh) {
 
 function _forecastSpans(days) {
     if (days <= 3) return [3];
-    if (days <= 7) return [7];
+    if (days <= 7) return [7, 3];
     if (days <= 10) return [10, 7, 3];
     if (days <= 15) return [15, 10, 7, 3];
     return [30, 15, 10, 7, 3];
@@ -220,7 +220,7 @@ function _fetchDailyAttempt(service, W, key, loc, gen, base, spans, spanIdx) {
                         maxC: parseFloat(day.tempMax),
                         minC: parseFloat(day.tempMin),
                         code: _qwCodeToWmo(day.iconDay),
-                        precipMm: parseFloat(day.precip) || 0,
+                        precipMm: (day.precip !== undefined && day.precip !== null) ? parseFloat(day.precip) : NaN,
                         snowCm: 0, // not separated in QWeather daily
                         uvMax: (day.uvIndex !== undefined) ? parseFloat(day.uvIndex) : NaN,
                         precipProb: (day.pop !== undefined) ? parseFloat(day.pop) : NaN,
@@ -343,8 +343,8 @@ function fetchHourly(service, W, dateStr) {
                         humidity: parseFloat(h.humidity),
                         humidityPercent: parseFloat(h.humidity),
                         pressureHpa: parseFloat(h.pressure),
-                        precipMm: parseFloat(h.precip) || 0,
-                        precipMmh: parseFloat(h.precip) || 0,
+                        precipMm: (h.precip !== undefined && h.precip !== null) ? parseFloat(h.precip) : NaN,
+                        precipMmh: (h.precip !== undefined && h.precip !== null) ? parseFloat(h.precip) : NaN,
                         precipProb: (h.pop !== undefined && h.pop !== null) ? parseFloat(h.pop) : NaN,
                         pop: (h.pop !== undefined && h.pop !== null) ? parseFloat(h.pop) : NaN,
                         dewPointC: (h.dew !== undefined && h.dew !== null)


### PR DESCRIPTION
## Summary
- fix QWeather hourly forecast field mapping used by the forecast UI
- use per-day sunrise and sunset times for expanded forecast rows
- request QWeather hourly data with a dynamic 24h/72h/168h range and show a clear message past the hourly limit
- preserve missing precipitation values as `NaN` and retry 7-day daily requests with a 3-day fallback

## Testing
- `/usr/lib/qt6/bin/qmllint $(find contents -name '*.qml' -print)`
- `npx -c 'node --check contents/ui/providers/qWeather.js'`
