### PR TITLE
Fix forecast popup sizing and layout

### DIFF
--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -37,18 +37,24 @@ Rectangle {
     property var weatherRoot
     property bool inSystemTray: false
 
-    // Layout.preferred* is what Plasma reads to size the panel popup window.
-    // width/height are used when the widget sits on the desktop.
+    // Layout.preferred* is provided by the fullRepresentation instance in main.qml.
+    // Keep implicit sizes here as defaults without fighting Plasma's popup sizing.
     // Compact size when no location is set to avoid overlapping other widgets.
     readonly property bool _hasLocation: weatherRoot && weatherRoot.hasSelectedTown
     readonly property bool _isRadarTab: _hasLocation && activeTab === 2 && showRadarTab
     readonly property bool isSimpleMode: (Plasmoid.configuration.widgetLayoutMode || "advanced") === "simple"
+    readonly property int _configuredPopupWidth: parseInt(Plasmoid.configuration.widgetWidth || 0, 10) || 0
+    readonly property int _configuredPopupHeight: parseInt(Plasmoid.configuration.widgetHeight || 0, 10) || 0
+    readonly property int _defaultPopupWidth: isSimpleMode ? 800 : 540
+    readonly property int _defaultPopupHeight: _isRadarTab ? 680 : 550
+    readonly property int _preferredPopupWidth: _hasLocation ? (_configuredPopupWidth > 0 ? _configuredPopupWidth : _defaultPopupWidth) : 280
+    readonly property int _preferredPopupHeight: _hasLocation ? (_configuredPopupHeight > 0 ? _configuredPopupHeight : _defaultPopupHeight) : 220
     Layout.minimumWidth:    _hasLocation ? (isSimpleMode ? 900 : 540) : 280
     Layout.minimumHeight:   _hasLocation ? (isSimpleMode ? 550 : 380) : 220
-    Layout.preferredWidth:  _hasLocation ? (isSimpleMode ? 800 : 540) : 280
-    Layout.preferredHeight: _hasLocation ? (isSimpleMode ? 550 : (_isRadarTab ? 680 : 550)) : 220
-    width:  _hasLocation ? (isSimpleMode ? 800 : 540) : 280
-    height: _hasLocation ? (isSimpleMode ? 550 : (_isRadarTab ? 680 : 550)) : 220
+    Layout.preferredWidth:  _preferredPopupWidth
+    Layout.preferredHeight: _preferredPopupHeight
+    implicitWidth:  _preferredPopupWidth
+    implicitHeight: _preferredPopupHeight
     clip: true
 
     // Maximum height: 90% of screen height, but no more than 40 grid units
@@ -618,6 +624,9 @@ Rectangle {
         StackLayout {
             id: tabContent
             Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.preferredHeight: 0
+            Layout.minimumHeight: 0
             visible: !fullView.isSimpleMode && fullView.showAnyTab
             currentIndex: fullView.activeTab
             // Explicitly follow the current child's implicitHeight

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -50,8 +50,29 @@ PlasmoidItem {
     // hints — they confuse Plasma's tray popup manager and cause a rapid
     // expanded toggling loop.  -1 lets Plasma use its own defaults.
     readonly property bool _isSimpleMode: (Plasmoid.configuration.widgetLayoutMode || "advanced") === "simple"
-    implicitWidth: inTray ? -1 : (_isSimpleMode ? 800 : 540)
-    implicitHeight: inTray ? -1 : 550
+
+    function _configInt(key) {
+        var value = Plasmoid.configuration[key];
+        var parsed = parseInt(value, 10);
+        return isNaN(parsed) ? 0 : parsed;
+    }
+
+    readonly property int _defaultPopupWidth: _isSimpleMode ? 800 : 540
+    readonly property int _defaultPopupHeight: 550
+    readonly property int _configuredPopupWidth: _configInt("widgetWidth")
+    readonly property int _configuredPopupHeight: _configInt("widgetHeight")
+    readonly property int _preferredPopupWidth: _configuredPopupWidth > 0 ? _configuredPopupWidth : _defaultPopupWidth
+    readonly property int _preferredPopupHeight: _configuredPopupHeight > 0 ? _configuredPopupHeight : _defaultPopupHeight
+    readonly property real _layoutDevicePixelRatio: {
+        if (typeof PlasmaCore !== "undefined" && PlasmaCore.Units && PlasmaCore.Units.devicePixelRatio)
+            return PlasmaCore.Units.devicePixelRatio;
+        return 1;
+    }
+    readonly property int _layoutPreferredPopupWidth: Math.round(_preferredPopupWidth * _layoutDevicePixelRatio)
+    readonly property int _layoutPreferredPopupHeight: Math.round(_preferredPopupHeight * _layoutDevicePixelRatio)
+
+    implicitWidth: inTray ? -1 : _preferredPopupWidth
+    implicitHeight: inTray ? -1 : _preferredPopupHeight
     switchWidth: inTray ? -1 : 200
     switchHeight: inTray ? -1 : 100
 
@@ -277,6 +298,8 @@ PlasmoidItem {
         // so Plasma can actually show the popup in the constrained tray area.
         // In the panel, enforce minimums as configured.
 
+        Layout.preferredWidth: root.inTray ? 0 : root._layoutPreferredPopupWidth
+        Layout.preferredHeight: root.inTray ? 0 : root._layoutPreferredPopupHeight
         Layout.minimumWidth: {
             if (root.inTray) return 0;
             if (!root.hasSelectedTown) return 280;


### PR DESCRIPTION
## Summary
- apply the popup preferred size on the `fullRepresentation` instance, following Plasma's popup sizing model
- stop `FullView` from overriding the popup geometry with fixed `width` and `height`
- let the forecast tab fill the remaining popup height so expanded hourly content no longer collapses the daily list to only a few visible rows

## Testing
- `qmllint contents/ui/main.qml contents/ui/FullView.qml`
- `git diff --check upstream/feature/1.7.0..HEAD`
- verified locally in Plasma with `forecastDays=16`; the forecast list now scrolls through July 22 and expanded hourly rows keep the following daily rows visible

<img width="1630" height="910" alt="Screenshot_20260707_142828" src="https://github.com/user-attachments/assets/6a797911-79cb-44e4-8170-8c8e82236207" />
<img width="1630" height="910" alt="Screenshot_20260707_142840" src="https://github.com/user-attachments/assets/f6001be2-c57f-42aa-8bd1-d09c498496a1" />
<img width="1630" height="910" alt="Screenshot_20260707_142906" src="https://github.com/user-attachments/assets/0a2fd23e-cfcd-4b08-9720-e08cc5c78d09" />
<img width="1630" height="910" alt="Screenshot_20260707_142914" src="https://github.com/user-attachments/assets/713f0a84-4d67-44b3-ae67-dfc7806fe51b" />
<img width="1630" height="910" alt="Screenshot_20260707_142936" src="https://github.com/user-attachments/assets/db48684f-9fbb-4bc8-b090-6fbbea970a5d" />
<img width="1630" height="910" alt="Screenshot_20260707_142947" src="https://github.com/user-attachments/assets/eaed4e8f-32b6-447a-889c-4456a75efab7" />
