### PR TITLE
Show location-local time hint in header

### DIFF
--- a/contents/ui/DetailsView.qml
+++ b/contents/ui/DetailsView.qml
@@ -2967,15 +2967,18 @@ Item {
                                                 // "Today" — always real today (for highlight)
                                                 readonly property int _todayDay: {
                                                     var _ = datetimeCard._tick;
-                                                    return new Date().getDate();
+                                                    var d = root.weatherRoot ? root.weatherRoot.locationNowDate() : new Date();
+                                                    return d.getDate();
                                                 }
                                                 readonly property int _todayMonth: {
                                                     var _ = datetimeCard._tick;
-                                                    return new Date().getMonth();
+                                                    var d = root.weatherRoot ? root.weatherRoot.locationNowDate() : new Date();
+                                                    return d.getMonth();
                                                 }
                                                 readonly property int _todayYear: {
                                                     var _ = datetimeCard._tick;
-                                                    return new Date().getFullYear();
+                                                    var d = root.weatherRoot ? root.weatherRoot.locationNowDate() : new Date();
+                                                    return d.getFullYear();
                                                 }
 
                                                 // "Viewed" month — today + offset
@@ -3282,7 +3285,7 @@ Item {
                                                     if (m === "sunset")
                                                         return r.formatTimeForDisplay(r.sunsetTimeText);
                                                     if (m === "upcoming") {
-                                                        var nowM = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+                                                        var nowM = (typeof r.locationNowMins === "function") ? r.locationNowMins() : ((new Date()).getHours() * 60 + (new Date()).getMinutes());
                                                         var riseM = SunPath.parseMins(r.sunriseTimeText);
                                                         var setM = SunPath.parseMins(r.sunsetTimeText);
                                                         if (riseM >= 0 && nowM < riseM)

--- a/contents/ui/ForecastView.qml
+++ b/contents/ui/ForecastView.qml
@@ -31,16 +31,13 @@ import "components"
 
 Item {
     id: forecastRoot
-
-    // Cached theme colors — a single PlasmaTheme attachment on the view root
-    // instead of one per item: every Kirigami.Theme attachment re-syncs
-    // (connect+disconnect on the window object) on each window expose, which
-    // froze popup opening while hundreds of delegate items were alive.
     readonly property color themeTextColor: Kirigami.Theme.textColor
     readonly property color themeBackgroundColor: Kirigami.Theme.backgroundColor
     property var weatherRoot
     property var verticalScrollView
     property int expandedIndex: -1
+    property int _singleExpandFetchGeneration: 0
+    property bool _needsForecastReset: true
 
     // ── Auto-open: expand the first available day's hourly forecast ────────
     readonly property bool autoOpen: Plasmoid.configuration.forecastAutoOpen !== false
@@ -58,6 +55,13 @@ Item {
     property int _expandAllActiveFetches: 0
     property int _expandAllFetchGeneration: 0
     readonly property int _expandAllMaxConcurrentFetches: 1
+    property var _viewportPrefetchQueue: []
+    property bool _viewportPrefetchInFlight: false
+    property string _viewportPrefetchActiveDate: ""
+    property int _viewportPrefetchGeneration: 0
+    readonly property int _viewportPrefetchRadius: 2
+    property var _hourlyDataVersions: ({})
+    property var _hourlyDisplayCache: ({})
 
     function _cancelExpandAllFetch(clearData) {
         _expandAllFetchGeneration++;
@@ -65,8 +69,390 @@ Item {
         _expandAllActiveFetches = 0;
         expandAllFetchPump.stop();
         _loadingDays = {};
-        if (clearData)
+        if (clearData) {
             _perDayHourlyData = {};
+            _hourlyDataVersions = {};
+            _hourlyDisplayCache = {};
+        }
+    }
+
+    function _cancelViewportPrefetch() {
+        _viewportPrefetchGeneration++;
+        _viewportPrefetchQueue = [];
+        if (_viewportPrefetchActiveDate) {
+            var loadDone = Object.assign({}, _loadingDays);
+            delete loadDone[_viewportPrefetchActiveDate];
+            _loadingDays = loadDone;
+        }
+        viewportPrefetchPump.stop();
+        viewportPrefetchDebounce.stop();
+    }
+
+    function _activeHourlyProvider() {
+        var provider = Plasmoid.configuration.weatherProvider || "adaptive";
+        return provider === "adaptive" ? "openMeteo" : provider;
+    }
+
+    function _hourlyCoverageHours() {
+        var provider = _activeHourlyProvider();
+        if (provider === "qWeather")
+            return 168;
+        if (provider === "weatherbit")
+            return 48;
+        return 0;
+    }
+
+    function _isDateOutsideHourlyCoverage(dateStr) {
+        var hours = _hourlyCoverageHours();
+        if (hours <= 0 || !dateStr)
+            return false;
+        var targetStartMs = weatherRoot ? weatherRoot.locationDateTimeToEpoch(dateStr, "00:00") : NaN;
+        if (isNaN(targetStartMs))
+            return false;
+        var horizon = new Date(Date.now() + hours * 60 * 60 * 1000);
+        return targetStartMs > horizon.getTime();
+    }
+
+    function _emptyHourlyMessage(dateStr) {
+        if (_isDateOutsideHourlyCoverage(dateStr)) {
+            var provider = _activeHourlyProvider();
+            if (provider === "qWeather")
+                return i18n("QWeather provides hourly forecasts for up to 168 hours (7 days). Daily forecast is still available for this date.");
+            if (provider === "weatherbit")
+                return i18n("Weatherbit provides hourly forecasts for up to 48 hours. Daily forecast is still available for this date.");
+        }
+        return i18n("No hourly data available");
+    }
+
+    function _forecastModelCount() {
+        if (!weatherRoot || weatherRoot.dailyData.length === 0)
+            return 0;
+        return weatherRoot.forecastDisplayCount(showToday, Plasmoid.configuration.forecastDays);
+    }
+
+    function _viewIndexToDataIndex(viewIndex) {
+        return weatherRoot ? (weatherRoot.firstForecastDataIndex(showToday) + viewIndex) : viewIndex;
+    }
+
+    function _dateStrForViewIndex(viewIndex) {
+        var dataIndex = _viewIndexToDataIndex(viewIndex);
+        if (!weatherRoot || !weatherRoot.dailyData[dataIndex])
+            return "";
+        return weatherRoot.dailyData[dataIndex].dateStr || "";
+    }
+
+    function _queueViewportPrefetch() {
+        if (expandAll || !visible || !weatherRoot)
+            return;
+
+        _cancelViewportPrefetch();
+
+        var modelCount = _forecastModelCount();
+        if (modelCount === 0)
+            return;
+
+        var firstVisible = 0;
+        var lastVisible = Math.min(modelCount - 1, 1);
+        if (forecastListView) {
+            firstVisible = forecastListView.indexAt(8, forecastListView.contentY + 1);
+            if (firstVisible < 0)
+                firstVisible = 0;
+            lastVisible = forecastListView.indexAt(8, forecastListView.contentY + forecastListView.height - 2);
+            if (lastVisible < 0)
+                lastVisible = Math.min(modelCount - 1, firstVisible + 2);
+        }
+
+        if (expandedIndex >= 0) {
+            firstVisible = Math.min(firstVisible, expandedIndex);
+            lastVisible = Math.max(lastVisible, expandedIndex);
+        }
+
+        firstVisible = Math.max(0, firstVisible - 1);
+        lastVisible = Math.min(modelCount - 1, lastVisible + _viewportPrefetchRadius);
+
+        var queue = [];
+        for (var viewIndex = firstVisible; viewIndex <= lastVisible; viewIndex++) {
+            var dateStr = _dateStrForViewIndex(viewIndex);
+            if (!dateStr)
+                continue;
+            if (_isDateOutsideHourlyCoverage(dateStr)) {
+                _storeHourlyData(dateStr, []);
+                continue;
+            }
+            if (Object.prototype.hasOwnProperty.call(_perDayHourlyData, dateStr) || _loadingDays[dateStr])
+                continue;
+            queue.push(dateStr);
+        }
+
+        if (queue.length === 0)
+            return;
+
+        _viewportPrefetchQueue = queue;
+        viewportPrefetchPump.restart();
+    }
+
+    function _pumpViewportPrefetchQueue() {
+        if (expandAll || !visible || !weatherRoot || _viewportPrefetchInFlight)
+            return;
+
+        var generation = _viewportPrefetchGeneration;
+        while (_viewportPrefetchQueue.length > 0) {
+            var dateStr = _viewportPrefetchQueue.shift();
+            if (!dateStr)
+                continue;
+            if (Object.prototype.hasOwnProperty.call(_perDayHourlyData, dateStr) || _loadingDays[dateStr])
+                continue;
+
+            _viewportPrefetchInFlight = true;
+            _viewportPrefetchActiveDate = dateStr;
+            var loading = Object.assign({}, _loadingDays);
+            loading[dateStr] = true;
+            _loadingDays = loading;
+
+            (function(ds, gen) {
+                weatherRoot.fetchHourlyForDateDirect(ds, function(hourlyArr) {
+                    var loadDone = Object.assign({}, forecastRoot._loadingDays);
+                    delete loadDone[ds];
+                    forecastRoot._loadingDays = loadDone;
+                    if (forecastRoot._viewportPrefetchActiveDate === ds)
+                        forecastRoot._viewportPrefetchActiveDate = "";
+                    forecastRoot._viewportPrefetchInFlight = false;
+                    if (gen !== forecastRoot._viewportPrefetchGeneration) {
+                        if (forecastRoot._viewportPrefetchQueue.length > 0)
+                            viewportPrefetchPump.restart();
+                        return;
+                    }
+                    forecastRoot._storeHourlyData(ds, hourlyArr);
+                    if (forecastRoot._viewportPrefetchQueue.length > 0)
+                        viewportPrefetchPump.restart();
+                });
+            })(dateStr, generation);
+            break;
+        }
+    }
+
+    function _timeToMinutes(timeText) {
+        if (!timeText || timeText === "--")
+            return -1;
+        var parts = timeText.split(":");
+        if (parts.length < 2)
+            return -1;
+        var hours = parseInt(parts[0], 10);
+        var minutes = parseInt(parts[1], 10);
+        if (isNaN(hours) || isNaN(minutes))
+            return -1;
+        return hours * 60 + minutes;
+    }
+
+    function _formatHourForDisplay(timeText) {
+        if (!timeText || timeText === "--")
+            return "--";
+        var parts = timeText.split(":");
+        if (parts.length < 2)
+            return timeText;
+        var hours = parseInt(parts[0], 10);
+        var minutes = parseInt(parts[1], 10);
+        if (isNaN(hours) || isNaN(minutes))
+            return timeText;
+        var date = new Date();
+        date.setHours(hours, minutes, 0, 0);
+        return Qt.formatTime(date, Qt.locale().timeFormat(Locale.ShortFormat));
+    }
+
+    function _sunTimeTextForDay(dayData, sunrise) {
+        if (!dayData)
+            return "--";
+        var daySpecific = sunrise ? dayData.sunriseTimeText : dayData.sunsetTimeText;
+        if (daySpecific && daySpecific !== "--")
+            return daySpecific;
+        if (!weatherRoot)
+            return "--";
+        return sunrise ? weatherRoot.sunriseTimeText : weatherRoot.sunsetTimeText;
+    }
+
+    function _storeHourlyData(dateStr, hourlyArr) {
+        var dataUpd = Object.assign({}, _perDayHourlyData);
+        dataUpd[dateStr] = hourlyArr || [];
+        _perDayHourlyData = dataUpd;
+
+        var versions = Object.assign({}, _hourlyDataVersions);
+        versions[dateStr] = (versions[dateStr] || 0) + 1;
+        _hourlyDataVersions = versions;
+        _hourlyDisplayCache = {};
+    }
+
+    function _seedHourlyDataFromPrefetch(dateStr) {
+        if (!weatherRoot || !dateStr)
+            return false;
+        if (Object.prototype.hasOwnProperty.call(_perDayHourlyData, dateStr))
+            return true;
+        if (typeof weatherRoot.prefetchedHourlyForDate !== "function")
+            return false;
+        var prefetched = weatherRoot.prefetchedHourlyForDate(dateStr);
+        if (prefetched === null || prefetched === undefined)
+            return false;
+        _storeHourlyData(dateStr, prefetched);
+        return true;
+    }
+
+    function _initialAutoOpenDateStr() {
+        if (!weatherRoot || weatherRoot.dailyData.length === 0 || expandAll || !autoOpen)
+            return "";
+        var firstDataIndex = weatherRoot.firstForecastDataIndex(forecastRoot.showToday);
+        if (firstDataIndex >= weatherRoot.dailyData.length)
+            return "";
+        return weatherRoot.dailyData[firstDataIndex].dateStr || "";
+    }
+
+    function _primeInitialExpandedState() {
+        var dateStr = _initialAutoOpenDateStr();
+        if (!dateStr)
+            return;
+        expandedIndex = 0;
+        _seedHourlyDataFromPrefetch(dateStr);
+    }
+
+    function _loadSingleExpandHourly(dateStr) {
+        if (!weatherRoot || !dateStr)
+            return;
+        if (_seedHourlyDataFromPrefetch(dateStr))
+            return;
+        if (typeof weatherRoot.isHourlyPrefetchInFlight === "function"
+                && weatherRoot.isHourlyPrefetchInFlight(dateStr)) {
+            var prefetchedLoading = Object.assign({}, _loadingDays);
+            prefetchedLoading[dateStr] = true;
+            _loadingDays = prefetchedLoading;
+            return;
+        }
+        if (Object.prototype.hasOwnProperty.call(_perDayHourlyData, dateStr))
+            return;
+        if (_loadingDays[dateStr])
+            return;
+        if (_isDateOutsideHourlyCoverage(dateStr)) {
+            _storeHourlyData(dateStr, []);
+            return;
+        }
+
+        _singleExpandFetchGeneration++;
+        var generation = _singleExpandFetchGeneration;
+        var loading = Object.assign({}, _loadingDays);
+        loading[dateStr] = true;
+        _loadingDays = loading;
+
+        weatherRoot.fetchHourlyForDateDirect(dateStr, function(hourlyArr) {
+            var loadDone = Object.assign({}, forecastRoot._loadingDays);
+            delete loadDone[dateStr];
+            forecastRoot._loadingDays = loadDone;
+            if (generation !== forecastRoot._singleExpandFetchGeneration)
+                return;
+            forecastRoot._storeHourlyData(dateStr, hourlyArr);
+        });
+    }
+
+    function _hourlyDisplayItems(dayData, hourlyData, dataIndex) {
+        if (!dayData || !hourlyData || hourlyData.length === 0)
+            return [];
+
+        var dateStr = dayData.dateStr || "";
+        var sunriseText = _sunTimeTextForDay(dayData, true);
+        var sunsetText = _sunTimeTextForDay(dayData, false);
+        var cacheKey = [
+            dateStr,
+            _hourlyDataVersions[dateStr] || 0,
+            showSunEvents ? 1 : 0,
+            (weatherRoot && dateStr === weatherRoot.locationDateString()) ? 1 : 0,
+            sunriseText,
+            sunsetText
+        ].join("|");
+        if (Object.prototype.hasOwnProperty.call(_hourlyDisplayCache, cacheKey))
+            return _hourlyDisplayCache[cacheKey];
+
+        var nowMins = -1;
+        var todayStr = weatherRoot ? weatherRoot.locationDateString() : "";
+        if (dateStr.length > 0 && dateStr === todayStr)
+            nowMins = (weatherRoot ? weatherRoot.locationNowMins() : -1) - 60;
+
+        var sunriseMins = _timeToMinutes(sunriseText);
+        var sunsetMins = _timeToMinutes(sunsetText);
+
+        var source = [];
+        for (var index = 0; index < hourlyData.length; index++) {
+            var hourly = hourlyData[index];
+            var mins = _timeToMinutes(hourly.hour);
+            if (nowMins >= 0 && mins >= 0 && mins < nowMins)
+                continue;
+            source.push(hourly);
+        }
+
+        var items = [];
+        var riseInserted = !showSunEvents || sunriseMins < 0 || (nowMins >= 0 && sunriseMins < nowMins);
+        var setInserted = !showSunEvents || sunsetMins < 0 || (nowMins >= 0 && sunsetMins < nowMins);
+        var firstHourly = true;
+
+        function pushSunItem(isSunriseItem, timeText) {
+            items.push({
+                key: dateStr + "|" + (isSunriseItem ? "sunrise" : "sunset") + "|" + timeText,
+                isSunrise: isSunriseItem,
+                isSunset: !isSunriseItem,
+                time: timeText,
+                displayTime: weatherRoot ? weatherRoot.formatTimeForDisplay(timeText) : timeText,
+                autoScrollTarget: false
+            });
+        }
+
+        for (var sourceIndex = 0; sourceIndex < source.length; sourceIndex++) {
+            var sourceHourly = source[sourceIndex];
+            var hourMins = _timeToMinutes(sourceHourly.hour);
+            if (!riseInserted && hourMins >= 0 && hourMins > sunriseMins) {
+                pushSunItem(true, sunriseText);
+                riseInserted = true;
+            }
+            if (!setInserted && hourMins >= 0 && hourMins > sunsetMins) {
+                pushSunItem(false, sunsetText);
+                setInserted = true;
+            }
+
+            var item = {};
+            for (var key in sourceHourly)
+                item[key] = sourceHourly[key];
+            item.key = dateStr + "|hour|" + (sourceHourly.hour || sourceIndex);
+            item.isSunrise = false;
+            item.isSunset = false;
+            item.displayTime = _formatHourForDisplay(sourceHourly.hour);
+            item.isNight = hourMins >= 0 && sunriseMins >= 0 && sunsetMins >= 0
+                ? (hourMins < sunriseMins || hourMins >= sunsetMins)
+                : false;
+            item.tempText = weatherRoot ? weatherRoot.tempValue(sourceHourly.tempC) : "--";
+            item.windText = weatherRoot ? weatherRoot.windValue(sourceHourly.windKmh) : "--";
+            item.pressureText = weatherRoot ? weatherRoot.pressureValue(sourceHourly.pressureHpa) : "--";
+            var kpEntry = weatherRoot
+                ? (weatherRoot.kpForecastForHour(dateStr, sourceHourly.hour || "") || weatherRoot.kpForecastForDate(dateStr))
+                : null;
+            item.kpText = (!kpEntry || kpEntry.kp === null || kpEntry.kp === undefined || isNaN(kpEntry.kp))
+                ? i18n("No info")
+                : "Kp " + kpEntry.kp.toFixed(1) + " (" + (kpEntry.gScale || "G0") + ")";
+            item.uvText = (sourceHourly.uvIndex === null || sourceHourly.uvIndex === undefined || isNaN(sourceHourly.uvIndex))
+                ? "--"
+                : "UV " + sourceHourly.uvIndex.toFixed(1);
+            item.precipText = weatherRoot ? weatherRoot.precipSumText(sourceHourly.precipMm) : "--";
+            item.visibilityText = weatherRoot ? weatherRoot.visibilityValue(sourceHourly.visibilityKm) : "--";
+            var precipProbText = W.hourlyPrecipProbText(sourceHourly.precipProb, sourceHourly.code);
+            var humidityText = (!isNaN(sourceHourly.humidity) && sourceHourly.humidity !== undefined)
+                ? Math.round(sourceHourly.humidity) + "%"
+                : "--";
+            item.precipDisplayText = precipProbText !== null ? precipProbText : humidityText;
+            item.precipRateVisible = sourceHourly.precipMm !== undefined
+                && !isNaN(sourceHourly.precipMm)
+                && sourceHourly.precipMm > 0
+                && W.isPrecipCode(sourceHourly.code);
+            item.precipRateText = weatherRoot ? weatherRoot.precipValue(sourceHourly.precipMm) : "--";
+            item.autoScrollTarget = firstHourly;
+            firstHourly = false;
+            items.push(item);
+        }
+
+        _hourlyDisplayCache[cacheKey] = items;
+        return items;
     }
 
     function _startExpandAll() {
@@ -76,11 +462,15 @@ Item {
         _expandAllActiveFetches = 0;
         _perDayHourlyData = {};
         var loading = {};
-        var total    = Math.min(Plasmoid.configuration.forecastDays, weatherRoot.dailyData.length);
-        var startDi  = forecastRoot.showToday ? 0 : 1;
-        for (var di = startDi; di < total; di++) {
+        var startDi  = weatherRoot.firstForecastDataIndex(forecastRoot.showToday);
+        var endDi    = Math.min(weatherRoot.dailyData.length, startDi + Plasmoid.configuration.forecastDays);
+        for (var di = startDi; di < endDi; di++) {
             var dateStr = weatherRoot.dailyData[di].dateStr || "";
             if (!dateStr) continue;
+            if (_isDateOutsideHourlyCoverage(dateStr)) {
+                _storeHourlyData(dateStr, []);
+                continue;
+            }
             _expandAllQueue.push(dateStr);
             loading[dateStr] = true;
         }
@@ -97,9 +487,7 @@ Item {
             (function(ds, gen) {
                 weatherRoot.fetchHourlyForDateDirect(ds, function(hourlyArr) {
                     if (gen !== forecastRoot._expandAllFetchGeneration) return;
-                    var dataUpd = Object.assign({}, forecastRoot._perDayHourlyData);
-                    dataUpd[ds] = hourlyArr || [];
-                    forecastRoot._perDayHourlyData = dataUpd;
+                    forecastRoot._storeHourlyData(ds, hourlyArr);
                     var loadDone = Object.assign({}, forecastRoot._loadingDays);
                     delete loadDone[ds];
                     forecastRoot._loadingDays = loadDone;
@@ -118,18 +506,43 @@ Item {
         onTriggered: forecastRoot._pumpExpandAllQueue()
     }
 
+    Timer {
+        id: viewportPrefetchPump
+        interval: 80
+        repeat: false
+        onTriggered: forecastRoot._pumpViewportPrefetchQueue()
+    }
+
+    Timer {
+        id: viewportPrefetchDebounce
+        interval: 120
+        repeat: false
+        onTriggered: forecastRoot._queueViewportPrefetch()
+    }
+
     function activateForecast() {
         _autoOpenDone = false;
         _collapsedDays = {};
         _loadingDays = {};
+        _cancelViewportPrefetch();
         if (expandAll) {
             _autoOpenDone = true;
             _perDayHourlyData = {};
+            _hourlyDataVersions = {};
+            _hourlyDisplayCache = {};
             _startExpandAll();
         } else {
-            _cancelExpandAllFetch(true);
-            _doAutoOpen();
+            _cancelExpandAllFetch(false);
+            var dateStr = _initialAutoOpenDateStr();
+            if (expandedIndex === 0 && dateStr) {
+                _autoOpenDone = true;
+                _loadSingleExpandHourly(dateStr);
+                viewportPrefetchDebounce.restart();
+            } else {
+                _doAutoOpen();
+            }
         }
+        _needsForecastReset = false;
     }
 
     onExpandAllChanged: {
@@ -138,15 +551,24 @@ Item {
             _autoOpenDone = true;
             _collapsedDays = {};
             _loadingDays   = {};
+            _singleExpandFetchGeneration++;
+            _cancelViewportPrefetch();
             if (visible && weatherRoot && weatherRoot.dailyData.length > 0)
                 _startExpandAll();
         } else {
             _cancelExpandAllFetch(true);
             _collapsedDays = {};
             _autoOpenDone = false;
+            _singleExpandFetchGeneration++;
+            _cancelViewportPrefetch();
             if (visible)
                 _doAutoOpen();
         }
+    }
+
+    onExpandedIndexChanged: {
+        if (!expandAll && visible)
+            viewportPrefetchDebounce.restart();
     }
 
     onAutoOpenChanged: {
@@ -164,55 +586,97 @@ Item {
             return;
         }
         if (!autoOpen) return;
-        var firstDataIndex = forecastRoot.showToday ? 0 : 1;
+        var firstDataIndex = weatherRoot.firstForecastDataIndex(forecastRoot.showToday);
         if (firstDataIndex >= weatherRoot.dailyData.length) return;
         forecastRoot.expandedIndex = 0;
-        weatherRoot.hourlyData = [];
-        weatherRoot.fetchHourlyForDate(weatherRoot.dailyData[firstDataIndex].dateStr || "");
+        forecastRoot._loadSingleExpandHourly(weatherRoot.dailyData[firstDataIndex].dateStr || "");
+        viewportPrefetchDebounce.restart();
     }
 
     onVisibleChanged: {
         if (visible) {
-            activateForecast();
+            if (_needsForecastReset) {
+                activateForecast();
+            } else if (!expandAll) {
+                viewportPrefetchDebounce.restart();
+            }
         } else {
             _cancelExpandAllFetch(false);
+            _cancelViewportPrefetch();
         }
     }
 
     Connections {
         target: weatherRoot
         function onDailyDataChanged() {
+            forecastRoot._needsForecastReset = true;
             if (!forecastRoot.visible) {
                 forecastRoot._autoOpenDone = false;
+                forecastRoot._singleExpandFetchGeneration++;
                 forecastRoot._cancelExpandAllFetch(true);
+                forecastRoot._primeInitialExpandedState();
                 return;
             }
             if (forecastRoot.expandAll) {
                 // expandAll always re-fetches when new data arrives —
                 // independent of autoOpen and _autoOpenDone.
                 forecastRoot._perDayHourlyData = {};
+                forecastRoot._hourlyDataVersions = {};
+                forecastRoot._hourlyDisplayCache = {};
                 forecastRoot._loadingDays      = {};
                 forecastRoot._startExpandAll();
-            } else if (forecastRoot.expandedIndex >= 0) {
-                // A day is already expanded (auto-opened or clicked) — re-fetch
-                // its hourly data so the panel doesn't keep showing the forecast
-                // from before the refresh. Keep the old data on screen while the
-                // fetch is in flight to avoid a collapse/flash.
+            } else {
+                forecastRoot._singleExpandFetchGeneration++;
+                forecastRoot._perDayHourlyData = {};
+                forecastRoot._hourlyDataVersions = {};
+                forecastRoot._hourlyDisplayCache = {};
+                forecastRoot._loadingDays = {};
+                forecastRoot._cancelViewportPrefetch();
                 var dataIndex = forecastRoot.showToday
                     ? forecastRoot.expandedIndex
                     : forecastRoot.expandedIndex + 1;
-                if (dataIndex < weatherRoot.dailyData.length)
-                    weatherRoot.fetchHourlyForDate(weatherRoot.dailyData[dataIndex].dateStr || "");
-                else
+                if (forecastRoot.expandedIndex >= 0 && dataIndex >= 0 && dataIndex < weatherRoot.dailyData.length) {
+                    forecastRoot._autoOpenDone = true;
+                    forecastRoot._loadSingleExpandHourly(weatherRoot.dailyData[dataIndex].dateStr || "");
+                    viewportPrefetchDebounce.restart();
+                } else {
                     forecastRoot.expandedIndex = -1;
-            } else {
-                forecastRoot._doAutoOpen();
+                    forecastRoot._autoOpenDone = false;
+                    forecastRoot._doAutoOpen();
+                }
             }
+        }
+
+        function onPrefetchedHourlyByDateChanged() {
+            if (!forecastRoot.visible) {
+                forecastRoot._primeInitialExpandedState();
+                return;
+            }
+            if (forecastRoot.expandAll || forecastRoot.expandedIndex < 0)
+                return;
+
+            var dataIndex = forecastRoot.showToday
+                ? forecastRoot.expandedIndex
+                : forecastRoot.expandedIndex + 1;
+            if (dataIndex < 0 || dataIndex >= weatherRoot.dailyData.length)
+                return;
+
+            var dateStr = weatherRoot.dailyData[dataIndex].dateStr || "";
+            if (!forecastRoot._seedHourlyDataFromPrefetch(dateStr))
+                return;
+
+            var loadDone = Object.assign({}, forecastRoot._loadingDays);
+            delete loadDone[dateStr];
+            forecastRoot._loadingDays = loadDone;
         }
     }
 
-    // Set implicit height based on content
-    implicitHeight: (weatherRoot && weatherRoot.dailyData.length > 0) ? forecastColumn.height : (emptyLabel.implicitHeight + 40)
+    Component.onCompleted: {
+        if (!visible)
+            _primeInitialExpandedState();
+    }
+
+    implicitHeight: parent ? parent.height : 220
 
     // Font for weather icons (wind direction glyph)
     FontLoader {
@@ -315,7 +779,8 @@ Item {
     }
 
     function _scrollParentVertically(wheel) {
-        if (!verticalScrollView)
+        var scrollTarget = verticalScrollView ? verticalScrollView : forecastListView;
+        if (!scrollTarget)
             return false;
         var delta = _wheelDeltaY(wheel);
         if (delta === 0)
@@ -323,14 +788,14 @@ Item {
         var scale = wheel.pixelDelta.y !== 0 ? 1 : 0.5;
         var amount = delta * scale;
 
-        var flick = verticalScrollView.flickableItem || verticalScrollView.contentItem || verticalScrollView;
+        var flick = scrollTarget.flickableItem || scrollTarget.contentItem || scrollTarget;
         if (flick && flick.contentHeight !== undefined && flick.contentY !== undefined) {
             var maxY = Math.max(0, flick.contentHeight - flick.height);
             flick.contentY = Math.max(0, Math.min(maxY, flick.contentY - amount));
             return true;
         }
 
-        var bar = verticalScrollView.ScrollBar ? verticalScrollView.ScrollBar.vertical : null;
+        var bar = scrollTarget.ScrollBar ? scrollTarget.ScrollBar.vertical : null;
         if (bar) {
             var maxPos = Math.max(0, 1.0 - bar.size);
             bar.position = Math.max(0, Math.min(maxPos, bar.position - amount / 1200));
@@ -368,28 +833,35 @@ Item {
         font: weatherRoot ? weatherRoot.wf(12, false) : Qt.font({})
     }
 
-    Column {
-        id: forecastColumn
-        width: parent.width
-        spacing: 0
+    ListView {
+        id: forecastListView
+        anchors.fill: parent
+        clip: true
         visible: weatherRoot && weatherRoot.dailyData.length > 0
+        model: forecastRoot._forecastModelCount()
+        spacing: 0
+        reuseItems: true
+        cacheBuffer: height * 2
+        boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar {
+            policy: ScrollBar.AsNeeded
+        }
+        ScrollBar.horizontal: ScrollBar {
+            policy: ScrollBar.AlwaysOff
+        }
+        onContentYChanged: viewportPrefetchDebounce.restart()
+        onHeightChanged: viewportPrefetchDebounce.restart()
+        onModelChanged: viewportPrefetchDebounce.restart()
+        Component.onCompleted: viewportPrefetchDebounce.restart()
 
-            Repeater {
-                model: {
-                    if (!weatherRoot || weatherRoot.dailyData.length === 0) return 0;
-                    var total = Math.min(Plasmoid.configuration.forecastDays, weatherRoot.dailyData.length);
-                    return forecastRoot.showToday ? total : Math.max(0, total - 1);
-                }
-
-                delegate: Column {
+        delegate: Column {
                     required property int index
-                    readonly property int dataIndex: forecastRoot.showToday ? index : index + 1
-                    width: parent.width
+                    readonly property int dataIndex: forecastRoot._viewIndexToDataIndex(index)
+                    width: ListView.view ? ListView.view.width : forecastRoot.width
                     spacing: 0
 
                     // Per-delegate hourly data: in expandAll mode pulls from the
-                    // per-day cache; in single-expand mode uses weatherRoot.hourlyData
-                    // (only valid for the currently expanded day).
+                    // per-day cache; single-expand reuses the same date-keyed cache.
                     property var _dayHourlyData: {
                         var dateStr = (weatherRoot && weatherRoot.dailyData[dataIndex])
                             ? (weatherRoot.dailyData[dataIndex].dateStr || "") : "";
@@ -397,47 +869,22 @@ Item {
                             if (forecastRoot._collapsedDays[dateStr]) return [];
                             return forecastRoot._perDayHourlyData[dateStr] || [];
                         }
-                        if (!forecastRoot.expandAll && forecastRoot.expandedIndex === index)
-                            return weatherRoot ? weatherRoot.hourlyData : [];
+                        if (!forecastRoot.expandAll && forecastRoot.expandedIndex === index && dateStr)
+                            return forecastRoot._perDayHourlyData[dateStr] || [];
                         return [];
                     }
 
-                    readonly property string _daySunriseText: {
-                        if (weatherRoot && weatherRoot.dailyData[dataIndex] && weatherRoot.dailyData[dataIndex].sunriseTimeText)
-                            return weatherRoot.dailyData[dataIndex].sunriseTimeText;
-                        return weatherRoot ? weatherRoot.sunriseTimeText : "--";
-                    }
-
-                    readonly property string _daySunsetText: {
-                        if (weatherRoot && weatherRoot.dailyData[dataIndex] && weatherRoot.dailyData[dataIndex].sunsetTimeText)
-                            return weatherRoot.dailyData[dataIndex].sunsetTimeText;
-                        return weatherRoot ? weatherRoot.sunsetTimeText : "--";
-                    }
-
-                    readonly property bool _dayOutsideQWeatherHourlyRange: {
-                        if ((Plasmoid.configuration.weatherProvider || "adaptive") !== "qWeather")
-                            return false;
-                        var ds = (weatherRoot && weatherRoot.dailyData[dataIndex])
-                            ? (weatherRoot.dailyData[dataIndex].dateStr || "") : "";
-                        if (!ds)
-                            return false;
-                        var parts = ds.split("-");
-                        if (parts.length < 3)
-                            return false;
-                        var year = parseInt(parts[0], 10);
-                        var month = parseInt(parts[1], 10) - 1;
-                        var day = parseInt(parts[2], 10);
-                        if (isNaN(year) || isNaN(month) || isNaN(day))
-                            return false;
-                        var dayStartMs = new Date(year, month, day, 0, 0, 0, 0).getTime();
-                        var hourlyLimitMs = (new Date()).getTime() + 168 * 3600 * 1000;
-                        return dayStartMs >= hourlyLimitMs;
-                    }
+                    property var _dayDisplayItems: forecastRoot._hourlyDisplayItems(
+                        weatherRoot && weatherRoot.dailyData[dataIndex] ? weatherRoot.dailyData[dataIndex] : null,
+                        _dayHourlyData,
+                        dataIndex)
 
                     readonly property bool _dayIsLoading: {
                         var dateStr = (weatherRoot && weatherRoot.dailyData[dataIndex])
                             ? (weatherRoot.dailyData[dataIndex].dateStr || "") : "";
                         if (forecastRoot.expandAll && dateStr && !forecastRoot._collapsedDays[dateStr])
+                            return !!forecastRoot._loadingDays[dateStr];
+                        if (!forecastRoot.expandAll && forecastRoot.expandedIndex === index && dateStr)
                             return !!forecastRoot._loadingDays[dateStr];
                         return false;
                     }
@@ -491,17 +938,12 @@ Item {
                                     width: parent.width
                                     elide: Text.ElideRight
                                     text: {
-                                        var di = dataIndex;
-                                        if (di === 0)
+                                        var ds = weatherRoot.dailyData[dataIndex].dateStr || "";
+                                        if (weatherRoot && ds === weatherRoot.locationDateString())
                                             return i18n("Today");
-                                        var ds = weatherRoot.dailyData[di].dateStr;
                                         if (!ds)
                                             return "";
-                                        var parts = ds.split("-");
-                                        if (parts.length !== 3)
-                                            return "";
-                                        var d = new Date(parts[0], parts[1] - 1, parts[2]);
-                                        return Qt.locale().dayName(d.getDay(), Locale.LongFormat);
+                                        return weatherRoot ? weatherRoot.dayNameForDateStr(ds, Locale.LongFormat) : "";
                                     }
                                     color: forecastRoot.themeTextColor
                                     font: weatherRoot.wf(12, true)
@@ -511,9 +953,9 @@ Item {
                                         var ds = weatherRoot.dailyData[dataIndex].dateStr || "";
                                         if (!ds)
                                             return "";
-                                        var d = new Date(ds);
-                                        var fmt = Qt.locale().dateFormat(Locale.ShortFormat);
-                                        return Qt.formatDate(d, fmt);
+                                        return weatherRoot
+                                            ? weatherRoot.formatDateStrForDisplay(ds, Qt.locale().dateFormat(Locale.ShortFormat))
+                                            : "";
                                     }
                                     color: forecastRoot.themeTextColor
                                     font: weatherRoot.wf(9, false)
@@ -634,7 +1076,7 @@ Item {
                                 Label {
                                     text: {
                                         var e = weatherRoot.kpForecastForDate(weatherRoot.dailyData[dataIndex].dateStr || "");
-                                        if (!e || isNaN(e.kp)) return i18n("No information");
+                                        if (!e || e.kp === null || e.kp === undefined || isNaN(e.kp)) return i18n("No information");
                                         return "Kp " + e.kp.toFixed(1) + " (" + (e.gScale || "G0") + ")";
                                     }
                                     color: Qt.rgba(forecastRoot.themeTextColor.r, forecastRoot.themeTextColor.g, forecastRoot.themeTextColor.b, 0.72)
@@ -666,7 +1108,7 @@ Item {
                                 Label {
                                     text: {
                                         var uv = weatherRoot.dailyData[dataIndex].uvMax;
-                                        return isNaN(uv) ? "--" : "UV " + uv.toFixed(1);
+                                        return (uv === null || uv === undefined || isNaN(uv)) ? "--" : "UV " + uv.toFixed(1);
                                     }
                                     color: Qt.rgba(forecastRoot.themeTextColor.r, forecastRoot.themeTextColor.g, forecastRoot.themeTextColor.b, 0.72)
                                     font: weatherRoot.wf(10, false)
@@ -787,10 +1229,7 @@ Item {
                                         forecastRoot.expandedIndex = -1;
                                     } else {
                                         forecastRoot.expandedIndex = index;
-                                        if (weatherRoot) {
-                                            weatherRoot.hourlyData = [];
-                                            weatherRoot.fetchHourlyForDate(dateStr);
-                                        }
+                                        forecastRoot._loadSingleExpandHourly(dateStr);
                                     }
                                 }
                             }
@@ -822,15 +1261,13 @@ Item {
                         // Plain loading text for single-expand mode
                         Label {
                             anchors.centerIn: parent
-                            width: parent.width - 24
                             visible: !_dayIsLoading && ((forecastRoot.expandAll && !forecastRoot._collapsedDays[weatherRoot.dailyData[dataIndex].dateStr || ""]) || forecastRoot.expandedIndex === index) && _dayHourlyData.length === 0
-                            text: _dayOutsideQWeatherHourlyRange
-                                ? i18n("QWeather provides hourly forecasts for up to 168 hours (7 days). Daily forecast is still available for this date.")
-                                : i18n("Loading hourly data…")
+                            text: forecastRoot._emptyHourlyMessage(weatherRoot.dailyData[dataIndex].dateStr || "")
                             color: forecastRoot.themeTextColor
                             font: weatherRoot ? weatherRoot.wf(11, false) : Qt.font({})
-                            wrapMode: Text.Wrap
+                            wrapMode: Text.WordWrap
                             horizontalAlignment: Text.AlignHCenter
+                            width: Math.max(0, parent.width - 24)
                         }
 
                         // Only instantiate the heavy hourly UI for the expanded day.
@@ -881,43 +1318,7 @@ Item {
                                     }
 
                                     // Build combined model same as cards (with sun events)
-                                    property var _hourlyWithSun: {
-                                        if (!_dayHourlyData || !_dayHourlyData.length) return [];
-                                        function toMins(t) {
-                                            if (!t || t === "--") return -1;
-                                            var p = t.split(":"); return p.length < 2 ? -1 : parseInt(p[0],10)*60+parseInt(p[1],10);
-                                        }
-                                        // For today (index 0) filter out past hours; keep 1 hour buffer so current hour stays visible
-                                        var nowMins = -1;
-                                        if (index === 0) {
-                                            var _now = new Date();
-                                            nowMins = _now.getHours() * 60 + _now.getMinutes() - 60;
-                                        }
-                                        var source = nowMins >= 0
-                                            ? _dayHourlyData.filter(function(h) { var m = toMins(h.hour); return m < 0 || m >= nowMins; })
-                                            : _dayHourlyData;
-                                        if (!forecastRoot.showSunEvents)
-                                            return source;
-                                        var rise = toMins(_daySunriseText);
-                                        var set_ = toMins(_daySunsetText);
-                                        // Only insert sun markers if they are still in the future (for today)
-                                        var riseInserted = rise < 0 || (nowMins >= 0 && rise < nowMins);
-                                        var setInserted  = set_  < 0 || (nowMins >= 0 && set_  < nowMins);
-                                        var result = [];
-                                        source.forEach(function(h) {
-                                            var hm = toMins(h.hour);
-                                            if (!riseInserted && hm >= 0 && hm > rise) {
-                                                result.push({ isSunrise: true, isSunset: false, time: _daySunriseText });
-                                                riseInserted = true;
-                                            }
-                                            if (!setInserted && hm >= 0 && hm > set_) {
-                                                result.push({ isSunrise: false, isSunset: true, time: _daySunsetText });
-                                                setInserted = true;
-                                            }
-                                            result.push(h);
-                                        });
-                                        return result;
-                                    }
+                                    property var _hourlyWithSun: _dayDisplayItems
 
                                     readonly property int colW: 100
                                     readonly property int colSpacing: 0
@@ -952,16 +1353,7 @@ Item {
                                                     height: 18
                                                     Label {
                                                         anchors.centerIn: parent
-                                                        text: {
-                                                            if (modelData.isSunrise || modelData.isSunset)
-                                                                return weatherRoot ? weatherRoot.formatTimeForDisplay(modelData.time) : "--";
-                                                            if (!modelData.hour || modelData.hour === "--") return "--";
-                                                            var parts = modelData.hour.split(":");
-                                                            if (parts.length < 2) return modelData.hour;
-                                                            var d = new Date();
-                                                            d.setHours(parseInt(parts[0],10), parseInt(parts[1],10), 0, 0);
-                                                            return Qt.formatTime(d, Qt.locale().timeFormat(Locale.ShortFormat));
-                                                        }
+                                                        text: modelData.displayTime || "--"
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(9, modelData.isSunrise || modelData.isSunset) : Qt.font({})
                                                         opacity: (modelData.isSunrise || modelData.isSunset) ? 0.9 : 0.7
@@ -992,18 +1384,7 @@ Item {
                                                                 return IconResolver.resolve("sunset", 32, forecastRoot.iconsBaseDir,
                                                                     forecastRoot.widgetIconTheme === "kde" ? "flat-color" :
                                                                     (forecastRoot.widgetIconTheme === "wi-font" || forecastRoot.widgetIconTheme === "custom") ? "symbolic" : forecastRoot.widgetIconTheme);
-                                                            var isNight = false;
-                                                            if (modelData.hour && modelData.hour !== "--") {
-                                                                var p2 = modelData.hour.split(":");
-                                                                if (p2.length >= 2) {
-                                                                    var hm2 = parseInt(p2[0],10)*60+parseInt(p2[1],10);
-                                                                    function _sm(t) { if (!t||t==="--") return -1; var p=t.split(":"); return p.length<2?-1:parseInt(p[0],10)*60+parseInt(p[1],10); }
-                                                                    var rise2=_sm(_daySunriseText);
-                                                                    var set2=_sm(_daySunsetText);
-                                                                    if (rise2>=0&&set2>=0) isNight=hm2<rise2||hm2>=set2;
-                                                                }
-                                                            }
-                                                            return forecastRoot.resolveConditionIcon(modelData.code||0, isNight, forecastRoot.iconSz);
+                                                            return forecastRoot.resolveConditionIcon(modelData.code || 0, modelData.isNight === true, forecastRoot.iconSz);
                                                         }
                                                         iconSize: 44
                                                         iconColor: forecastRoot.themeTextColor
@@ -1120,7 +1501,7 @@ Item {
                                                     Label {
                                                         anchors.centerIn: parent
                                                         text: (modelData.isSunrise || modelData.isSunset) ? i18n(modelData.isSunrise ? "Sunrise" : "Sunset")
-                                                              : (weatherRoot ? weatherRoot.tempValue(modelData.tempC) : "--")
+                                                              : (modelData.tempText || "--")
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, !(modelData.isSunrise || modelData.isSunset)) : Qt.font({})
                                                         opacity: (modelData.isSunrise || modelData.isSunset) ? 0.75 : 1.0
@@ -1154,13 +1535,7 @@ Item {
                                                     }
                                                     Label {
                                                         visible: !parent._isSun
-                                                        text: {
-                                                            if (parent._isSun) return "";
-                                                            var ppText = W.hourlyPrecipProbText(modelData.precipProb, modelData.code);
-                                                            if (ppText !== null) return ppText;
-                                                            var h = modelData.humidity;
-                                                            return (!isNaN(h) && h !== undefined) ? Math.round(h) + "%" : "--";
-                                                        }
+                                                        text: modelData.precipDisplayText || "--"
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
                                                         opacity: 0.7
@@ -1190,7 +1565,7 @@ Item {
                                                         spacing: 2
                                                         Label {
                                                             visible: !parent.parent._isSun
-                                                            text: weatherRoot && modelData.windKmh !== undefined ? weatherRoot.windValue(modelData.windKmh) : "--"
+                                                            text: modelData.windText || "--"
                                                             color: forecastRoot.themeTextColor
                                                             font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
                                                             opacity: 0.7
@@ -1233,7 +1608,7 @@ Item {
                                                     }
                                                     Label {
                                                         visible: !parent._isSun
-                                                        text: weatherRoot ? weatherRoot.pressureValue(modelData.pressureHpa) : "--"
+                                                        text: modelData.pressureText || "--"
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
                                                         opacity: 0.7
@@ -1269,14 +1644,7 @@ Item {
                                                     }
                                                     Label {
                                                         visible: !parent._isSun
-                                                        text: {
-                                                            if (!weatherRoot) return i18n("No info");
-                                                            var d = weatherRoot.dailyData[dataIndex].dateStr || "";
-                                                            var e = weatherRoot.kpForecastForHour(d, modelData.hour || "")
-                                                                    || weatherRoot.kpForecastForDate(d);
-                                                            if (!e || isNaN(e.kp)) return i18n("No info");
-                                                            return "Kp " + e.kp.toFixed(1) + " (" + (e.gScale || "G0") + ")";
-                                                        }
+                                                        text: modelData.kpText || i18n("No info")
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
                                                         opacity: 0.7
@@ -1312,11 +1680,7 @@ Item {
                                                     }
                                                     Label {
                                                         visible: !parent._isSun
-                                                        text: {
-                                                            var uv = modelData.uvIndex;
-                                                            if (W.isNotSupported(uv)) return i18n("Not supported");
-                                                            return (uv === undefined || isNaN(uv)) ? "--" : "UV " + uv.toFixed(1);
-                                                        }
+                                                        text: modelData.uvText || "--"
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
                                                         opacity: 0.7
@@ -1352,7 +1716,7 @@ Item {
                                                     }
                                                     Label {
                                                         visible: !parent._isSun
-                                                        text: weatherRoot ? weatherRoot.precipSumText(modelData.precipMm) : "--"
+                                                        text: modelData.precipText || "--"
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
                                                         opacity: 0.7
@@ -1388,7 +1752,7 @@ Item {
                                                     }
                                                     Label {
                                                         visible: !parent._isSun
-                                                        text: weatherRoot ? weatherRoot.visibilityValue(modelData.visibilityKm) : "--"
+                                                        text: modelData.visibilityText || "--"
                                                         color: forecastRoot.themeTextColor
                                                         font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
                                                         opacity: 0.7
@@ -1429,462 +1793,13 @@ Item {
 
                         Component {
                             id: cardsHourlyComponent
-                            Item {
+                            HourlyCardsView {
                                 anchors.fill: parent
-
-                                // ── CARDS LAYOUT ───────────────────────────────────
-                                ScrollView {
-                                    id: hourlyScrollView
-                                    anchors.fill: parent
-                                    anchors.margins: 8
-                                    clip: true
-                                    // ScrollView itself does not have flickableDirection.
-                                    // This property needs to be set on the internal flickableItem.
-                                    Component.onCompleted: {
-                                        if (hourlyScrollView.flickableItem) {
-                                            hourlyScrollView.flickableItem.flickableDirection = Flickable.HorizontalFlick;
-                                        }
-                                    }
-                                    contentWidth: hourlyRow.implicitWidth
-                                    ScrollBar.vertical.policy: ScrollBar.AlwaysOff
-                                    ScrollBar.horizontal.policy: ScrollBar.AsNeeded
-
-                                    NumberAnimation {
-                                        id: hourlyWheelAnimation
-                                        target: hourlyScrollView.ScrollBar.horizontal
-                                        property: "position"
-                                        duration: 140
-                                        easing.type: Easing.OutCubic
-                                    }
-
-                                    // Auto-scroll to current hour for "Today" (index === 0)
-                                    Timer {
-                                        id: scrollTimer
-                                        interval: 150
-                                        onTriggered: {
-                                            if (index !== 0 || !_dayHourlyData.length) return;
-                                            var now = new Date();
-                                            var currentTotalMins = now.getHours() * 60 + now.getMinutes();
-                                            var closestIdx = 0;
-                                            var minDiff = 86400;
-                                            for (var i = 0; i < _dayHourlyData.length; i++) {
-                                                var h = _dayHourlyData[i].hour;
-                                                if (!h) continue;
-                                                var parts = h.split(":");
-                                                if (parts.length < 2) continue;
-                                                var hm = parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
-                                                var diff = Math.abs(hm - currentTotalMins);
-                                                if (diff < minDiff) {
-                                                    minDiff = diff;
-                                                    closestIdx = i;
-                                                }
-                                            }
-                                            if (forecastRoot.showSunEvents && _daySunriseText && _daySunsetText) {
-                                                function toMins(t) {
-                                                    if (!t || t === "--") return -1;
-                                                    var p = t.split(":"); return p.length < 2 ? -1 : parseInt(p[0],10)*60+parseInt(p[1],10);
-                                                }
-                                                var rise = toMins(_daySunriseText);
-                                                var set_ = toMins(_daySunsetText);
-                                                var targetMins = closestIdx < _dayHourlyData.length ? toMins(_dayHourlyData[closestIdx].hour) : -1;
-                                                if (rise >= 0 && targetMins >= 0 && rise < targetMins) closestIdx++;
-                                                if (set_ >= 0 && targetMins >= 0 && set_ < targetMins) closestIdx++;
-                                            }
-                                            var hourlyWidth = forecastRoot._hourlyCardWidth;
-                                            var sunWidth = 70;
-                                            var spacing = 6;
-                                            var scrollPos = 0;
-                                            if (forecastRoot.showSunEvents && _daySunriseText && _daySunsetText) {
-                                                function toMins2(t) {
-                                                    if (!t || t === "--") return -1;
-                                                    var p = t.split(":"); return p.length < 2 ? -1 : parseInt(p[0],10)*60+parseInt(p[1],10);
-                                                }
-                                                var rise2 = toMins2(_daySunriseText);
-                                                var set2 = toMins2(_daySunsetText);
-                                                for (var j = 0; j < closestIdx; j++) {
-                                                    var hm2 = toMins2(_dayHourlyData[j].hour);
-                                                    if (rise2 >= 0 && hm2 > rise2) { scrollPos += sunWidth + spacing; rise2 = -1; }
-                                                    if (set2 >= 0 && hm2 > set2) { scrollPos += sunWidth + spacing; set2 = -1; }
-                                                    scrollPos += hourlyWidth + spacing;
-                                                }
-                                            } else {
-                                                scrollPos = closestIdx * (hourlyWidth + spacing);
-                                            }
-                                            var bar = hourlyScrollView.ScrollBar.horizontal;
-                                            if (!bar) return;
-                                            var contentW = hourlyRow.implicitWidth || hourlyRow.width || (_dayHourlyData.length * (hourlyWidth + spacing));
-                                            var viewW = hourlyScrollView.width;
-                                            if (contentW > viewW) {
-                                                var maxPos = Math.max(0, contentW - viewW);
-                                                var targetPos = Math.min(scrollPos, maxPos);
-                                                bar.position = targetPos / contentW;
-                                            }
-                                        }
-                                    }
-                                    Connections {
-                                        target: weatherRoot
-                                        function onHourlyDataChanged() {
-                                            if (index !== 0 || !_dayHourlyData.length) return;
-                                            scrollTimer.start();
-                                        }
-                                    }
-
-                                    Row {
-                                        id: hourlyRow
-                                        spacing: 6
-                                        height: parent.height
-
-                                        // Build combined model: hourly entries + sunrise/sunset marker cards
-                                        // inserted between the hour that precedes each event.
-                                        property var _hourlyWithSun: {
-                                            if (!_dayHourlyData || !_dayHourlyData.length) return [];
-                                            function toMins(t) {
-                                                if (!t || t === "--") return -1;
-                                                var p = t.split(":"); return p.length < 2 ? -1 : parseInt(p[0],10)*60+parseInt(p[1],10);
-                                            }
-                                            // For today (index 0) filter out past hours; keep 1 hour buffer
-                                            var nowMins = -1;
-                                            if (index === 0) {
-                                                var _now = new Date();
-                                                nowMins = _now.getHours() * 60 + _now.getMinutes() - 60;
-                                            }
-                                            var source = nowMins >= 0
-                                                ? _dayHourlyData.filter(function(h) { var m = toMins(h.hour); return m < 0 || m >= nowMins; })
-                                                : _dayHourlyData;
-                                            if (!forecastRoot.showSunEvents)
-                                                return source;
-                                            var rise = toMins(_daySunriseText);
-                                            var set_ = toMins(_daySunsetText);
-                                            var riseInserted = rise < 0 || (nowMins >= 0 && rise < nowMins);
-                                            var setInserted  = set_  < 0 || (nowMins >= 0 && set_  < nowMins);
-                                            var result = [];
-                                            source.forEach(function(h) {
-                                                var hm = toMins(h.hour);
-                                                if (!riseInserted && hm >= 0 && hm > rise) {
-                                                    result.push({ isSunrise: true,  isSunset: false, time: _daySunriseText });
-                                                    riseInserted = true;
-                                                }
-                                                if (!setInserted && hm >= 0 && hm > set_) {
-                                                    result.push({ isSunset: true,  isSunrise: false, time: _daySunsetText });
-                                                    setInserted = true;
-                                                }
-                                                result.push(h);
-                                            });
-                                            return result;
-                                        }
-
-                                        Repeater {
-                                            model: parent._hourlyWithSun
-
-                                            delegate: Rectangle {
-                                                required property var modelData
-                                                // Sunrise/sunset cards are slim; hourly cards are full height
-                                                width: (modelData.isSunrise || modelData.isSunset) ? 70 : forecastRoot._hourlyCardWidth
-                                                height: forecastRoot._hourlyCardHeight
-                                                radius: 8
-                                                color: (modelData.isSunrise || modelData.isSunset)
-                                                    ? Qt.rgba(forecastRoot.themeTextColor.r, forecastRoot.themeTextColor.g, forecastRoot.themeTextColor.b, 0.04)
-                                                    : Qt.rgba(forecastRoot.themeTextColor.r, forecastRoot.themeTextColor.g, forecastRoot.themeTextColor.b, 0.08)
-                                                border.color: Qt.rgba(forecastRoot.themeTextColor.r, forecastRoot.themeTextColor.g, forecastRoot.themeTextColor.b, 0.12)
-                                                border.width: 1
-
-                                                // Only the branch this card needs is instantiated — a dormant
-                                                // twin layout used to double every card's item and icon count.
-                                                Loader {
-                                                    anchors.fill: parent
-                                                    sourceComponent: (modelData.isSunrise === true || modelData.isSunset === true) ? sunCardComp : hourCardComp
-                                                }
-
-                                                // ── Sunrise / Sunset card ─────────────────────────────
-                                                Component {
-                                                    id: sunCardComp
-                                                    Item {
-                                                        ColumnLayout {
-                                                            anchors.centerIn: parent
-                                                            spacing: 6
-                                                            WeatherIcon {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                iconInfo: IconResolver.resolve(
-                                                                    modelData.isSunrise ? "sunrise" : "sunset",
-                                                                    32,
-                                                                    forecastRoot.iconsBaseDir,
-                                                                    forecastRoot.widgetIconTheme === "kde" ? "flat-color" :
-                                                                    (forecastRoot.widgetIconTheme === "wi-font" || forecastRoot.widgetIconTheme === "custom" || forecastRoot.widgetIconTheme === "kde-symbolic") ? "symbolic" : forecastRoot.widgetIconTheme)
-                                                                iconSize: 32
-                                                                iconColor: forecastRoot.themeTextColor
-                                                            }
-                                                            Label {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                text: weatherRoot ? weatherRoot.formatTimeForDisplay(modelData.time) : "--"
-                                                                color: forecastRoot.themeTextColor
-                                                                font: weatherRoot ? weatherRoot.wf(10, true) : Qt.font({ bold: true })
-                                                            }
-                                                        }
-                                                    }
-                                                }
-
-                                                // ── Regular hourly card ───────────────────────────────
-                                                Component {
-                                                    id: hourCardComp
-                                                    Item {
-                                                        ColumnLayout {
-                                                            anchors {
-                                                                fill: parent
-                                                                margins: 6
-                                                            }
-                                                            spacing: 4
-
-                                                            Label {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                text: {
-                                                                    if (!modelData.hour || modelData.hour === "--")
-                                                                        return "--";
-                                                                    var parts = modelData.hour.split(":");
-                                                                    if (parts.length < 2)
-                                                                        return modelData.hour;
-                                                                    var h = parseInt(parts[0], 10);
-                                                                    var m = parseInt(parts[1], 10);
-                                                                    if (isNaN(h) || isNaN(m))
-                                                                        return modelData.hour;
-                                                                    var d = new Date();
-                                                                    d.setHours(h, m, 0, 0);
-                                                                    return Qt.formatTime(d, Qt.locale().timeFormat(Locale.ShortFormat));
-                                                                }
-                                                                color: forecastRoot.themeTextColor
-                                                                font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                            }
-
-                                                            WeatherIcon {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                iconInfo: {
-                                                                    // Derive night flag from the hour vs sunrise/sunset
-                                                                    var isNight = false;
-                                                                    if (modelData.hour && modelData.hour !== "--") {
-                                                                        var parts = modelData.hour.split(":");
-                                                                        if (parts.length >= 2) {
-                                                                            var hMins = parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
-                                                                            function parseSunMins(t) {
-                                                                                if (!t || t === "--") return -1;
-                                                                                var p = t.split(":");
-                                                                                return p.length < 2 ? -1 : parseInt(p[0], 10) * 60 + parseInt(p[1], 10);
-                                                                            }
-                                                                            var rise = parseSunMins(_daySunriseText);
-                                                                            var set_ = parseSunMins(_daySunsetText);
-                                                                            if (rise >= 0 && set_ >= 0)
-                                                                                isNight = hMins < rise || hMins >= set_;
-                                                                        }
-                                                                    }
-                                                                    return forecastRoot.resolveConditionIcon(
-                                                                        modelData.code || 0, isNight,
-                                                                        forecastRoot.iconSz);
-                                                                }
-                                                                iconSize: 48
-                                                            }
-
-                                                            Label {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                text: weatherRoot ? weatherRoot.tempValue(modelData.tempC) : "--"
-                                                                color: forecastRoot.themeTextColor
-                                                                font: weatherRoot ? weatherRoot.wf(11, true) : Qt.font({ bold: true })
-                                                            }
-
-                                                            RowLayout {
-                                                                visible: forecastRoot._hourlyShowWind
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 4
-                                                                Label {
-                                                                    text: weatherRoot && modelData.windKmh !== undefined ? weatherRoot.windValue(modelData.windKmh) : "--"
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                                Text {
-                                                                    visible: weatherRoot && !isNaN(modelData.windDeg)
-                                                                    text: W.windDirectionGlyph(modelData.windDeg)
-                                                                    font.family: wiFont.status === FontLoader.Ready ? wiFont.font.family : ""
-                                                                    font.pixelSize: 20
-                                                                    color: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                visible: forecastRoot._hourlyShowPressure
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 3
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("pressure", 24, forecastRoot.iconsBaseDir, forecastRoot.itemsIconTheme)
-                                                                    iconSize: 24
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: weatherRoot ? weatherRoot.pressureValue(modelData.pressureHpa) : "--"
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                visible: forecastRoot._hourlyShowKpIndex
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 3
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("spaceweather", 24, forecastRoot.iconsBaseDir, forecastRoot.itemsIconTheme)
-                                                                    iconSize: 24
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: {
-                                                                        if (!weatherRoot) return i18n("No info");
-                                                                        var d = weatherRoot.dailyData[dataIndex].dateStr || "";
-                                                                        var e = weatherRoot.kpForecastForHour(d, modelData.hour || "")
-                                                                                || weatherRoot.kpForecastForDate(d);
-                                                                        if (!e || isNaN(e.kp)) return i18n("No info");
-                                                                        return "Kp " + e.kp.toFixed(1) + " (" + (e.gScale || "G0") + ")";
-                                                                    }
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                visible: forecastRoot._hourlyShowUvIndex
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 3
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("uvindex", 24, forecastRoot.iconsBaseDir, forecastRoot.itemsIconTheme)
-                                                                    iconSize: 24
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: {
-                                                                        var uv = modelData.uvIndex;
-                                                                        if (W.isNotSupported(uv)) return i18n("Not supported");
-                                                                        return (uv === undefined || isNaN(uv)) ? "--" : "UV " + uv.toFixed(1);
-                                                                    }
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                visible: forecastRoot._hourlyShowPrecipSum
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 3
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("precipsum", 24, forecastRoot.iconsBaseDir, forecastRoot.itemsIconTheme)
-                                                                    iconSize: 24
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: weatherRoot ? weatherRoot.precipSumText(modelData.precipMm) : "--"
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                visible: forecastRoot._hourlyShowVisibility
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 3
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("visibility", 24, forecastRoot.iconsBaseDir, forecastRoot.itemsIconTheme)
-                                                                    iconSize: 24
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: weatherRoot ? weatherRoot.visibilityValue(modelData.visibilityKm) : "--"
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: 3
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("umbrella", 32, forecastRoot.iconsBaseDir,
-                                                                        forecastRoot.widgetIconTheme === "kde" ? "flat-color" :
-                                                                        (forecastRoot.widgetIconTheme === "wi-font" || forecastRoot.widgetIconTheme === "custom" || forecastRoot.widgetIconTheme === "kde-symbolic") ? "symbolic" : forecastRoot.widgetIconTheme)
-                                                                    iconSize: 32
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: {
-                                                                        var ppText = W.hourlyPrecipProbText(modelData.precipProb, modelData.code);
-                                                                        if (ppText !== null) return ppText;
-                                                                        var h = modelData.humidity;
-                                                                        return (!isNaN(h) && h !== undefined) ? Math.round(h) + "%" : "--";
-                                                                    }
-                                                                    color: forecastRoot.themeTextColor
-                                                                    font: weatherRoot ? weatherRoot.wf(9, false) : Qt.font({})
-                                                                }
-                                                            }
-
-                                                            RowLayout {
-                                                                Layout.alignment: Qt.AlignHCenter
-                                                                spacing: -5
-                                                                // Open-Meteo can report a trace precip amount (e.g. 0.1 mm)
-                                                                // for an hour whose weather code and probability are dry.
-                                                                // Only show the rate when the code itself implies precipitation,
-                                                                // so it doesn't contradict a clear/sunny icon at 0% probability.
-                                                                visible: modelData.precipMm !== undefined && !isNaN(modelData.precipMm)
-                                                                         && modelData.precipMm > 0 && W.isPrecipCode(modelData.code)
-                                                                WeatherIcon {
-                                                                    iconInfo: IconResolver.resolve("preciprate", 32, forecastRoot.iconsBaseDir,
-                                                                        forecastRoot.widgetIconTheme === "kde" ? "flat-color" :
-                                                                        (forecastRoot.widgetIconTheme === "wi-font" || forecastRoot.widgetIconTheme === "custom" || forecastRoot.widgetIconTheme === "kde-symbolic") ? "symbolic" : forecastRoot.widgetIconTheme)
-                                                                    iconSize: 32
-                                                                    iconColor: forecastRoot.themeTextColor
-                                                                    opacity: 0.6
-                                                                    Layout.alignment: Qt.AlignVCenter
-                                                                }
-                                                                Label {
-                                                                    text: weatherRoot ? weatherRoot.precipValue(modelData.precipMm) : "--"
-                                                                    color: forecastRoot.themeTextColor
-                                                                    opacity: 0.6
-                                                                    font: weatherRoot ? weatherRoot.wf(8, false) : Qt.font({})
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                MouseArea {
-                                    anchors.fill: hourlyScrollView
-                                    acceptedButtons: Qt.NoButton
-                                    onWheel: function(wheel) {
-                                        var bar = hourlyScrollView.ScrollBar.horizontal;
-                                        if (!bar)
-                                            return;
-                                        if (forecastRoot._hourlyWheelWantsHorizontal(wheel)) {
-                                            var delta = wheel.angleDelta.x !== 0 ? wheel.angleDelta.x : forecastRoot._wheelDeltaX(wheel);
-                                            var pixelDelta = wheel.angleDelta.x === 0 && wheel.pixelDelta.x !== 0;
-                                            if (delta === 0) {
-                                                delta = wheel.angleDelta.y !== 0 ? wheel.angleDelta.y : forecastRoot._wheelDeltaY(wheel);
-                                                pixelDelta = wheel.angleDelta.y === 0 && wheel.pixelDelta.y !== 0;
-                                            }
-                                            var maxPos = Math.max(0, 1.0 - bar.size);
-                                            var targetPos = pixelDelta
-                                                ? Math.max(0, Math.min(maxPos, bar.position - delta / Math.max(1, hourlyRow.implicitWidth)))
-                                                : Math.max(0, Math.min(maxPos, bar.position - (delta / 120) * 0.15));
-                                            hourlyWheelAnimation.to = targetPos;
-                                            hourlyWheelAnimation.restart();
-                                            wheel.accepted = true;
-                                        } else {
-                                            wheel.accepted = forecastRoot._scrollParentVertically(wheel);
-                                        }
-                                    }
-                                }
+                                hostRoot: forecastRoot
+                                serviceRoot: weatherRoot
+                                wiFont: wiFont
+                                hourlyItems: _dayDisplayItems
+                                autoScrollToCurrent: weatherRoot && (weatherRoot.dailyData[dataIndex].dateStr || "") === weatherRoot.locationDateString()
                             }
                         }
                     }
@@ -1895,6 +1810,5 @@ Item {
                         color: Qt.rgba(forecastRoot.themeTextColor.r, forecastRoot.themeTextColor.g, forecastRoot.themeTextColor.b, 0.08)
                     }
                 }
-            }
         }
     }

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -253,14 +253,50 @@ Rectangle {
                 Layout.alignment: Qt.AlignVCenter
             }
 
-            Label {
+            Item {
+                id: headerLocationInfo
                 Layout.fillWidth: !headerDateTimeLabel.visible
-                text: weatherRoot ? (weatherRoot._activeLocName, weatherRoot._locName()) : (Plasmoid.configuration.locationName || "")
-                // #2
-                color: Kirigami.Theme.textColor
-                font: weatherRoot ? weatherRoot.wf(11, false) : Qt.font({})
-                elide: Text.ElideRight
-                verticalAlignment: Text.AlignVCenter
+                implicitWidth: headerLocationContent.implicitWidth
+                implicitHeight: headerLocationContent.implicitHeight
+
+                Row {
+                    id: headerLocationContent
+                    width: parent.width
+                    height: Math.max(headerLocationNameLabel.implicitHeight, headerLocationTimeHintLabel.implicitHeight)
+                    spacing: 4
+
+                    Label {
+                        id: headerLocationNameLabel
+                        width: Math.max(0, Math.min(implicitWidth, headerLocationInfo.width - (headerLocationTimeHintLabel.visible ? headerLocationTimeHintLabel.implicitWidth + headerLocationContent.spacing : 0)))
+                        text: weatherRoot ? (weatherRoot._activeLocName, weatherRoot._locName()) : (Plasmoid.configuration.locationName || "")
+                        color: Kirigami.Theme.textColor
+                        font: weatherRoot ? weatherRoot.wf(11, false) : Qt.font({})
+                        elide: Text.ElideRight
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    Label {
+                        id: headerLocationTimeHintLabel
+                        visible: !headerDateTimeLabel.visible && weatherRoot && weatherRoot.shouldShowLocationTimeHint()
+                        color: Kirigami.Theme.disabledTextColor
+                        opacity: 0.9
+                        font: weatherRoot ? weatherRoot.wf(10, false) : Qt.font({})
+                        verticalAlignment: Text.AlignVCenter
+                        text: {
+                            var _ = _tick;
+                            return weatherRoot ? "\u00B7 " + weatherRoot.locationTimeHintText() : "";
+                        }
+
+                        property int _tick: 0
+                        Timer {
+                            interval: 60000
+                            running: headerLocationTimeHintLabel.visible
+                            repeat: true
+                            triggeredOnStart: true
+                            onTriggered: headerLocationTimeHintLabel._tick++
+                        }
+                    }
+                }
             }
 
             // ── Header date / time ────────────────────────────────────────

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -107,8 +107,6 @@ Rectangle {
         return want;
     }
 
-    // Whether not-currently-shown tabs stay instantiated. True while the
-    // popup is open and always on the desktop (Planar), which has no popup.
     readonly property bool _keepHiddenTabs: (weatherRoot && weatherRoot.expanded === true) || Plasmoid.formFactor === 0
 
     // Reset to the configured default tab every time the popup opens
@@ -301,7 +299,7 @@ Rectangle {
                     running: headerDateTimeLabel.visible
                     triggeredOnStart: true
                     onTriggered: {
-                        var now = new Date();
+                        var now = weatherRoot ? weatherRoot.locationNowDate() : new Date();
                         var dateStr = headerDateTimeLabel._formatDate(now);
                         var timeStr = headerDateTimeLabel._formatTime(now);
                         var sep = (dateStr.length > 0 && timeStr.length > 0) ? "  " : "";
@@ -624,7 +622,7 @@ Rectangle {
             implicitHeight: (children && children[currentIndex]) ? children[currentIndex].implicitHeight : 0
 
             // Reach the (lazily-loaded) ForecastView for external activation.
-            readonly property var forecastViewItem: forecastLoader.item ? forecastLoader.item.forecastViewItem : null
+            readonly property var forecastViewItem: forecastScrollView.forecastViewItem
 
             onCurrentIndexChanged: {
                 // ForecastView.onVisibleChanged already triggers activateForecast()
@@ -638,73 +636,50 @@ Rectangle {
             // ── Details tab ───────────────────────────────────────────
             Item {
                 id: detailsTab
-                implicitHeight: detailsLoader.item ? detailsLoader.item.implicitHeight : 220
-                Loader {
-                    id: detailsLoader
+                implicitHeight: detailsView.implicitHeight
+                DetailsView {
+                    id: detailsView
                     anchors.fill: parent
-                    asynchronous: true
-                    // Latch only while the popup is open (always on desktop, where
-                    // there is no popup): hidden tabs unload on close, so the
-                    // expose-time PlasmaTheme sync storm on reopen only covers
-                    // one tab's items instead of every tab ever visited.
-                    active: detailsTab.StackLayout.isCurrentItem || (item !== null && fullView._keepHiddenTabs)
-                    sourceComponent: DetailsView {
-                        weatherRoot: fullView.weatherRoot
-                    }
-                }
-                BusyIndicator {
-                    anchors.centerIn: parent
-                    running: detailsLoader.status === Loader.Loading
-                    visible: running
+                    weatherRoot: fullView.weatherRoot
                 }
             }
 
             // ── Forecast tab ──────────────────────────────────────────
             Item {
                 id: forecastTab
-                implicitHeight: forecastLoader.item ? forecastLoader.item.implicitHeight : 220
-                Loader {
-                    id: forecastLoader
+                implicitHeight: forecastScrollView.implicitHeight
+                ScrollView {
+                    id: forecastScrollView
                     anchors.fill: parent
-                    asynchronous: true
-                    active: forecastTab.StackLayout.isCurrentItem || (item !== null && fullView._keepHiddenTabs)
-                    sourceComponent: ScrollView {
-                        id: forecastScrollView
-                        clip: true
-                        // Expose the inner ForecastView for external activation
-                        property alias forecastViewItem: forecastView
-                        ScrollBar.vertical.policy: ScrollBar.AsNeeded
-                        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-                        implicitHeight: forecastView.implicitHeight
-                        // No contentWidth binding: availableWidth depends on the
-                        // scrollbar, which depends on implicitWidth, which depends
-                        // on contentWidth — a binding loop. ForecastView.width is
-                        // bound to availableWidth below, which is all we need.
+                    clip: true
+                    property alias forecastViewItem: forecastView
+                    ScrollBar.vertical.policy: ScrollBar.AsNeeded
+                    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+                    implicitHeight: forecastView.implicitHeight
 
-                        ForecastView {
-                            id: forecastView
-                            weatherRoot: fullView.weatherRoot
-                            verticalScrollView: forecastScrollView.contentItem
-                            width: forecastScrollView.availableWidth
-                        }
+                    ForecastView {
+                        id: forecastView
+                        weatherRoot: fullView.weatherRoot
+                        verticalScrollView: forecastScrollView.contentItem
+                        width: forecastScrollView.availableWidth
                     }
-                }
-                BusyIndicator {
-                    anchors.centerIn: parent
-                    running: forecastLoader.status === Loader.Loading
-                    visible: running
                 }
             }
 
             // ── Radar tab ─────────────────────────────────────────────
             Item {
                 id: radarTab
+                property bool wasLoaded: false
                 implicitHeight: radarLoader.item ? radarLoader.item.implicitHeight : 380
                 Loader {
                     id: radarLoader
                     anchors.fill: parent
                     asynchronous: true
-                    active: radarTab.StackLayout.isCurrentItem || (item !== null && fullView._keepHiddenTabs)
+                    active: radarTab.StackLayout.isCurrentItem || (radarTab.wasLoaded && fullView._keepHiddenTabs)
+                    onStatusChanged: {
+                        if (status === Loader.Ready)
+                            radarTab.wasLoaded = true;
+                    }
                     sourceComponent: RadarView {
                         weatherRoot: fullView.weatherRoot
                     }
@@ -726,12 +701,8 @@ Rectangle {
             visible: Plasmoid.configuration.showUpdateText !== false && weatherRoot && !weatherRoot.loading && (weatherRoot.updateText || "").length > 0
             text: {
                 var t = weatherRoot ? weatherRoot.updateText : "";
-                if (fullView._isRadarTab) {
-                    if ((Plasmoid.configuration.radarProvider || "rainviewer") === "librewxr")
-                        t += " · " + i18n("Radar:") + " <a href='https://librewxr.net/'>LibreWXR</a>";
-                    else if ((Plasmoid.configuration.radarLayer || "rainviewer") === "rainviewer")
-                        t += " · " + i18n("Radar:") + " <a href='https://www.rainviewer.com/'>Rain Viewer</a>";
-                }
+                if (fullView._isRadarTab && (Plasmoid.configuration.radarLayer || "rainviewer") === "rainviewer")
+                    t += " · " + i18n("Radar:") + " <a href='https://www.rainviewer.com/'>Rain Viewer</a>";
                 return t;
             }
             textFormat: Text.RichText

--- a/contents/ui/SimpleView.qml
+++ b/contents/ui/SimpleView.qml
@@ -389,17 +389,18 @@ ColumnLayout {
             Repeater {
                 model: {
                     if (!weatherRoot || !weatherRoot.dailyData) return 0;
-                    var total = Math.min(simpleView.forecastDays, weatherRoot.dailyData.length);
-                    return simpleView.showToday ? total : Math.max(0, total - 1);
+                    return weatherRoot.forecastDisplayCount(simpleView.showToday, simpleView.forecastDays);
                 }
 
                 delegate: Rectangle {
                     required property int index
-                    readonly property int dataIndex: simpleView.showToday ? index : index + 1
+                    readonly property int dataIndex: weatherRoot ? (weatherRoot.firstForecastDataIndex(simpleView.showToday) + index) : index
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     radius: 8
-                    color: dataIndex === 0
+                    readonly property string dayDateStr: day && day.dateStr ? day.dateStr : ""
+                    readonly property bool isToday: weatherRoot && dayDateStr.length > 0 && dayDateStr === weatherRoot.locationDateString()
+                    color: isToday
                         ? Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
                         : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.06)
 
@@ -420,15 +421,10 @@ ColumnLayout {
                             Layout.alignment: Qt.AlignHCenter
                             text: {
                                 if (!day) return "";
-                                if (dataIndex === 0) return i18n("Today");
                                 var ds = day.dateStr || "";
-                                if (ds) {
-                                    var parts = ds.split("-");
-                                    if (parts.length === 3) {
-                                        var dt = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
-                                        return Qt.locale().dayName(dt.getDay(), Locale.LongFormat);
-                                    }
-                                }
+                                if (isToday) return i18n("Today");
+                                if (ds && weatherRoot)
+                                    return weatherRoot.dayNameForDateStr(ds, Locale.LongFormat);
                                 return new Date(day.time * 1000).toLocaleDateString(Qt.locale(), "dddd");
                             }
                             color: Kirigami.Theme.textColor
@@ -445,8 +441,9 @@ ColumnLayout {
                             text: {
                                 if (!day) return "";
                                 var ds = day.dateStr || "";
-                                var d2 = ds ? new Date(ds) : new Date(day.time * 1000);
-                                return Qt.formatDate(d2, Qt.locale().dateFormat(Locale.ShortFormat));
+                                if (ds && weatherRoot)
+                                    return weatherRoot.formatDateStrForDisplay(ds, Qt.locale().dateFormat(Locale.ShortFormat));
+                                return Qt.formatDate(new Date(day.time * 1000), Qt.locale().dateFormat(Locale.ShortFormat));
                             }
                             color: Kirigami.Theme.textColor
                             opacity: 0.5

--- a/contents/ui/TooltipContent.qml
+++ b/contents/ui/TooltipContent.qml
@@ -510,7 +510,7 @@ Item {
                     var pts = s.split(":");
                     return parseInt(pts[0]) * 60 + parseInt(pts[1]);
                 }
-                var nowMM = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+                var nowMM = (typeof r.locationNowMins === "function") ? r.locationNowMins() : ((new Date()).getHours() * 60 + (new Date()).getMinutes());
                 var riseMM = parseMoonMins(r.moonriseTimeText);
                 var setMM = parseMoonMins(r.moonsetTimeText);
                 var useSetM = riseMM >= 0 && nowMM >= riseMM && (setMM < 0 || nowMM < setMM);
@@ -541,7 +541,7 @@ Item {
                     var pts = s.split(":");
                     return parseInt(pts[0]) * 60 + parseInt(pts[1]);
                 }
-                var nowMM2 = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+                var nowMM2 = (typeof r.locationNowMins === "function") ? r.locationNowMins() : ((new Date()).getHours() * 60 + (new Date()).getMinutes());
                 var riseMM2 = parseMoonMins2(r.moonriseTimeText);
                 var setMM2 = parseMoonMins2(r.moonsetTimeText);
                 var useSetM2 = riseMM2 >= 0 && nowMM2 >= riseMM2 && (setMM2 < 0 || nowMM2 < setMM2);
@@ -593,7 +593,7 @@ Item {
                     : [{ iconInfo: infoSet, showIcon: showIcon, text: setTime }];
             }
             if (mode === "upcoming") {
-                var nowM = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+                var nowM = (typeof r.locationNowMins === "function") ? r.locationNowMins() : ((new Date()).getHours() * 60 + (new Date()).getMinutes());
                 var riseM = parseMins(r.sunriseTimeText);
                 var setM = parseMins(r.sunsetTimeText);
                 var useSet = riseM >= 0 && nowM >= riseM && (setM < 0 || nowM < setM);

--- a/contents/ui/WeatherService.qml
+++ b/contents/ui/WeatherService.qml
@@ -641,6 +641,8 @@ QtObject {
                         patched.sunsetTimeText = Qt.formatTime(new Date(d.daily.sunset[0]), "HH:mm");
                     if (d.utc_offset_seconds !== undefined)
                         patched.locationUtcOffsetMins = Math.round(d.utc_offset_seconds / 60);
+                    if (d.timezone_abbreviation !== undefined && d.timezone_abbreviation !== null)
+                        patched.locationTimezoneAbbrev = "" + d.timezone_abbreviation;
                     r.weatherDataStaged = patched;
                 }
             } catch (e) {}

--- a/contents/ui/WeatherService.qml
+++ b/contents/ui/WeatherService.qml
@@ -36,8 +36,44 @@ QtObject {
     id: service
 
     // ── Public interface ──────────────────────────────────────────────────
-    /** Reference to the PlasmoidItem root — set from main.qml */
-    property var weatherRoot
+    /** Real PlasmoidItem root — set from main.qml. */
+    property var rootRef
+
+    /** Provider-facing mutable sink. Direct-hourly fetch may override this. */
+    property var weatherRoot: rootRef
+
+    // Provider modules are imported JS files. Mutating nested fields on
+    // `service.weatherRoot` does not reliably notify QML here, so providers
+    // write to these pass-through properties on `service` instead.
+    property bool loading: false
+    onLoadingChanged: if (rootRef) rootRef.loading = loading
+
+    property string updateText: ""
+    onUpdateTextChanged: if (rootRef) rootRef.updateText = updateText
+
+    property var weatherDataStaged: null
+    onWeatherDataStagedChanged: if (rootRef) rootRef.weatherDataStaged = weatherDataStaged
+
+    property var aqiDataStaged: null
+    onAqiDataStagedChanged: if (rootRef) rootRef.aqiDataStaged = aqiDataStaged
+
+    property var pollenDataStaged: []
+    onPollenDataStagedChanged: if (rootRef) rootRef.pollenDataStaged = pollenDataStaged || []
+
+    property var weatherAlerts: []
+    onWeatherAlertsChanged: if (rootRef) rootRef.weatherAlerts = weatherAlerts || []
+
+    property var hourlyData: []
+    onHourlyDataChanged: if (weatherRoot) weatherRoot.hourlyData = hourlyData || []
+
+    property var spaceWeather: null
+    onSpaceWeatherChanged: if (rootRef) rootRef.spaceWeather = spaceWeather
+
+    property var spaceWeatherDailyForecast: ({})
+    onSpaceWeatherDailyForecastChanged: if (rootRef) rootRef.spaceWeatherDailyForecast = spaceWeatherDailyForecast || ({})
+
+    property var spaceWeatherForecastPeriods: []
+    onSpaceWeatherForecastPeriodsChanged: if (rootRef) rootRef.spaceWeatherForecastPeriods = spaceWeatherForecastPeriods || []
 
     property string _updateProvider: ""
     property real _updateTimestampMs: 0
@@ -162,11 +198,11 @@ QtObject {
         interval: 20000
         repeat: false
         onTriggered: {
-            if (weatherRoot && weatherRoot.loading) {
+            if (service.loading) {
                 console.warn("[WeatherService] Safety timeout — forcing loading=false");
-                weatherRoot.loading = false;
+                service.loading = false;
                 service._clearUpdateMetadata();
-                weatherRoot.updateText = i18n("Update timed out. Tap to retry.");
+                service.updateText = i18n("Update timed out. Tap to retry.");
             }
         }
     }
@@ -178,6 +214,13 @@ QtObject {
         onTriggered: service._refreshRelativeUpdateText()
     }
 
+    function _hasConfiguredLocation() {
+        var name = (locationName || "").trim();
+        if (name.length > 0)
+            return true;
+        return !isNaN(latitude) && !isNaN(longitude) && (latitude !== 0 || longitude !== 0);
+    }
+
     // ── Public methods ────────────────────────────────────────────────────
 
     /** Full weather refresh — current + daily forecast.
@@ -186,8 +229,8 @@ QtObject {
         _refreshGen++;
         _safetyTimer.stop();
 
-        var r = weatherRoot;
-        if (!r.hasSelectedTown) {
+        var r = service;
+        if (!_hasConfiguredLocation()) {
             r.loading = false;
             service._clearUpdateMetadata();
             r.updateText = "";
@@ -232,470 +275,69 @@ QtObject {
 
         var _p = _providers();
         if (!_p || !_p.fetchHourly(ap, service, dateStr))
-            weatherRoot.hourlyData = [];
+            service.hourlyData = [];
     }
 
     /**
-     * Parallel variant used by ForecastView's expand-all mode.
-     * Fires a real XHR for the given dateStr and calls callback(hourlyArray)
-     * when done — never touches weatherRoot.hourlyData, so multiple in-flight
-     * requests don't clobber each other.
-     *
-     * Falls back to fetchHourlyForDate (sequential) for providers that don't
-     * expose a direct fetch yet.
+     * Non-mutating hourly fetch used by ForecastView prefetch/expand-all and
+     * notification helpers. Reuses the same per-provider parsing path as the
+     * normal sequential fetch, but captures the result into a temporary sink so
+     * shared weatherRoot.hourlyData is never overwritten by concurrent calls.
      */
     function fetchHourlyForDateDirect(dateStr, callback) {
         var provider = Plasmoid.configuration.weatherProvider || "adaptive";
         var ap = (provider === "adaptive") ? "openMeteo" : provider;
-        var lat = service.latitude;
-        var lon = service.longitude;
-        var tz  = service.timezone || "auto";
+        if (typeof callback !== "function")
+            return;
+        var _p = _providers();
+        if (!_p) {
+            callback([]);
+            return;
+        }
 
-        // ── BBC Weather ───────────────────────────────────────────────────────
-        // BBC's id resolution lives in its provider module, so delegate the
-        // whole parallel fetch there instead of inlining it here.
+        // BBC resolves its location id inside the provider module, so reuse
+        // its direct path instead of proxying through the shared hourly sink.
         if (ap === "bbc") {
-            var _pB = _providers();
-            if (!_pB || !_pB.fetchHourlyDirect(ap, service, dateStr, callback))
+            if (!_p.fetchHourlyDirect(ap, service, dateStr, callback))
                 callback([]);
             return;
         }
 
-        // ── Open-Meteo ────────────────────────────────────────────────────────
-        if (ap === "openMeteo") {
-            var url = "https://api.open-meteo.com/v1/forecast"
-                + "?latitude="  + encodeURIComponent(lat)
-                + "&longitude=" + encodeURIComponent(lon)
-                + "&timezone="  + encodeURIComponent(tz)
-                + "&hourly=temperature_2m,weather_code,wind_speed_10m,"
-                + "wind_direction_10m,relative_humidity_2m,"
-                + "precipitation_probability,precipitation"
-                + "&start_date=" + encodeURIComponent(dateStr)
-                + "&end_date="   + encodeURIComponent(dateStr)
-                + "&wind_speed_unit=kmh"
-                + W.openMeteoModelParam(service.openMeteoModel, service.countryCode);
-            var xhr = new XMLHttpRequest();
-            xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText);
-                    var h = d.hourly || {}; var times = h.time || []; var arr = [];
-                    for (var i = 0; i < times.length; i++) {
-                        var t = times[i];
-                        arr.push({
-                            hour:       t.length >= 16 ? t.substr(11, 5) : "--",
-                            tempC:      h.temperature_2m            ? h.temperature_2m[i]            : NaN,
-                            code:       h.weather_code              ? h.weather_code[i]              : 0,
-                            windKmh:    h.wind_speed_10m            ? h.wind_speed_10m[i]            : NaN,
-                            windDeg:    h.wind_direction_10m        ? h.wind_direction_10m[i]        : NaN,
-                            humidity:   h.relative_humidity_2m      ? h.relative_humidity_2m[i]      : NaN,
-                            precipProb: h.precipitation_probability ? h.precipitation_probability[i] : NaN,
-                            precipMm:   h.precipitation             ? h.precipitation[i]             : NaN
-                        });
-                    }
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── met.no ────────────────────────────────────────────────────────────
-        if (ap === "metno") {
-            var alt = service.altitude;
-            var url = "https://api.met.no/weatherapi/locationforecast/2.0/complete?lat="
-                + encodeURIComponent(lat) + "&lon=" + encodeURIComponent(lon)
-                + ((!isNaN(alt) && alt !== 0) ? "&altitude=" + Math.round(alt) : "");
-            var xhr = new XMLHttpRequest();
-            xhr.open("GET", url);
-            xhr.setRequestHeader("User-Agent",
-                "AdvancedWeatherWidget/1.0 github.com/pnedyalkov91/advanced-weather-widget");
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    if (d.properties && d.properties.timeseries)
-                        d.properties.timeseries.forEach(function(ts) {
-                            var dd = new Date(ts.time);
-                            if (Qt.formatDate(dd, "yyyy-MM-dd") !== dateStr) return;
-                            var det = ts.data && ts.data.instant ? ts.data.instant.details : null;
-                            if (!det) return;
-                            var sym = ts.data && ts.data.next_1_hours && ts.data.next_1_hours.summary
-                                ? ts.data.next_1_hours.summary.symbol_code : "";
-                            var p1h = ts.data && ts.data.next_1_hours && ts.data.next_1_hours.details
-                                ? ts.data.next_1_hours.details : null;
-                            arr.push({
-                                hour:       Qt.formatTime(dd, "HH:mm"),
-                                tempC:      det.air_temperature,
-                                code:       W.metNoSymbolToWmo(sym),
-                                windKmh:    det.wind_speed !== undefined ? det.wind_speed * 3.6 : NaN,
-                                windDeg:    det.wind_from_direction !== undefined ? det.wind_from_direction : NaN,
-                                humidity:   det.relative_humidity,
-                                precipProb: p1h && p1h.probability_of_precipitation !== undefined
-                                                ? p1h.probability_of_precipitation : NaN,
-                                precipMm:   p1h && p1h.precipitation_amount !== undefined
-                                                ? p1h.precipitation_amount : NaN
-                            });
-                        });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── OpenWeather ───────────────────────────────────────────────────────
-        if (ap === "openWeather") {
-            var key = service._owKey(); if (!key) { callback([]); return; }
-            var url = "https://api.openweathermap.org/data/2.5/forecast?lat=" + lat
-                + "&lon=" + lon + "&units=metric&appid=" + encodeURIComponent(key);
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var fc = JSON.parse(xhr.responseText); var arr = [];
-                    if (fc.list) fc.list.forEach(function(e) {
-                        var d = new Date(e.dt * 1000);
-                        if (Qt.formatDate(d, "yyyy-MM-dd") !== dateStr) return;
-                        arr.push({
-                            hour:       Qt.formatTime(d, "HH:mm"),
-                            tempC:      e.main.temp,
-                            code:       W.openWeatherCodeToWmo(e.weather[0].id),
-                            windKmh:    e.wind ? e.wind.speed * 3.6 : NaN,
-                            windDeg:    e.wind ? e.wind.deg : NaN,
-                            humidity:   e.main.humidity,
-                            precipProb: e.pop !== undefined ? Math.round(e.pop * 100) : NaN,
-                            precipMm:   e.rain && e.rain["1h"] !== undefined ? e.rain["1h"]
-                                        : e.rain && e.rain["3h"] !== undefined ? e.rain["3h"] / 3 : NaN
-                        });
-                    });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── Pirate Weather ────────────────────────────────────────────────────
-        if (ap === "pirateWeather") {
-            var key = service._pwKey(); if (!key) { callback([]); return; }
-            var url = "https://api.pirateweather.net/forecast/"
-                + encodeURIComponent(key) + "/" + lat + "," + lon
-                + "?units=ca&exclude=minutely,daily,alerts&extend=hourly";
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    function _pwIcon(icon) {
-                        if (!icon) return 2;
-                        if (icon.indexOf("clear") >= 0) return 0;
-                        if (icon.indexOf("partly-cloudy") >= 0) return 2;
-                        if (icon === "cloudy") return 3;
-                        if (icon.indexOf("rain") >= 0) return 63;
-                        if (icon.indexOf("snow") >= 0) return 73;
-                        if (icon.indexOf("sleet") >= 0) return 66;
-                        if (icon === "fog" || icon === "mist" || icon === "haze") return 45;
-                        if (icon.indexOf("thunder") >= 0) return 95;
-                        return 2;
-                    }
-                    if (d.hourly && d.hourly.data) d.hourly.data.forEach(function(h) {
-                        var dt = new Date(h.time * 1000);
-                        if (Qt.formatDate(dt, "yyyy-MM-dd") !== dateStr) return;
-                        arr.push({
-                            hour:       Qt.formatTime(dt, "HH:mm"),
-                            tempC:      h.temperature,
-                            code:       _pwIcon(h.icon),
-                            windKmh:    h.windSpeed !== undefined ? h.windSpeed : NaN,
-                            windDeg:    h.windBearing !== undefined ? h.windBearing : NaN,
-                            humidity:   h.humidity !== undefined ? Math.round(h.humidity * 100) : NaN,
-                            precipProb: h.precipProbability !== undefined ? Math.round(h.precipProbability * 100) : NaN,
-                            precipMm:   h.precipIntensity !== undefined ? h.precipIntensity : NaN
-                        });
-                    });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── WeatherAPI ────────────────────────────────────────────────────────
-        if (ap === "weatherApi") {
-            var key = service._waKey(); if (!key) { callback([]); return; }
-            var url = "https://api.weatherapi.com/v1/forecast.json?key="
-                + encodeURIComponent(key)
-                + "&q=" + encodeURIComponent(lat + "," + lon)
-                + "&days=7&aqi=no&alerts=no&dt=" + dateStr;
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    if (d.forecast && d.forecast.forecastday)
-                        d.forecast.forecastday.forEach(function(day) {
-                            if (day.date !== dateStr) return;
-                            if (day.hour) day.hour.forEach(function(h) {
-                                arr.push({
-                                    hour:       Qt.formatTime(new Date(h.time_epoch * 1000), "HH:mm"),
-                                    tempC:      h.temp_c,
-                                    code:       W.weatherApiCodeToWmo(h.condition.code),
-                                    windKmh:    h.wind_kph,
-                                    windDeg:    h.wind_degree,
-                                    humidity:   h.humidity,
-                                    precipProb: h.chance_of_rain !== undefined ? h.chance_of_rain : NaN,
-                                    precipMm:   h.precip_mm !== undefined ? h.precip_mm : NaN
-                                });
-                            });
-                        });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── Visual Crossing ───────────────────────────────────────────────────
-        if (ap === "visualCrossing") {
-            var key = service._vcKey(); if (!key) { callback([]); return; }
-            var url = "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/"
-                + lat + "," + lon + "/" + dateStr + "/" + dateStr
-                + "?key=" + encodeURIComponent(key)
-                + "&unitGroup=metric&include=hours&iconSet=icons2";
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    function _vcIcon(icon) {
-                        if (!icon) return 2;
-                        if (icon.indexOf("clear") >= 0) return 0;
-                        if (icon.indexOf("partly-cloudy") >= 0) return 2;
-                        if (icon === "cloudy") return 3;
-                        if (icon.indexOf("thunder") >= 0) return 95;
-                        if (icon.indexOf("snow") >= 0) return 73;
-                        if (icon === "sleet") return 66;
-                        if (icon.indexOf("rain") >= 0 || icon.indexOf("shower") >= 0) return 63;
-                        if (icon === "fog") return 45;
-                        return 2;
-                    }
-                    if (d.days && d.days.length > 0 && d.days[0].hours)
-                        d.days[0].hours.forEach(function(h) {
-                            arr.push({
-                                hour:       h.datetime ? h.datetime.substring(0, 5) : "--",
-                                tempC:      h.temp,
-                                code:       _vcIcon(h.icon),
-                                windKmh:    h.windspeed  !== undefined ? h.windspeed  : NaN,
-                                windDeg:    h.winddir    !== undefined ? h.winddir    : NaN,
-                                humidity:   h.humidity   !== undefined ? Math.round(h.humidity) : NaN,
-                                precipProb: h.precipprob !== undefined ? Math.round(h.precipprob) : NaN,
-                                precipMm:   h.precip     !== undefined ? h.precip : NaN
-                            });
-                        });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── Tomorrow.io ───────────────────────────────────────────────────────
-        if (ap === "tomorrowIo") {
-            var key = service._tioKey(); if (!key) { callback([]); return; }
-            var url = "https://api.tomorrow.io/v4/weather/forecast"
-                + "?location=" + lat + "," + lon
-                + "&timesteps=1h&units=metric&apikey=" + encodeURIComponent(key);
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    var m = {1000:0,1100:1,1101:2,1102:3,1001:3,2000:45,2100:45,4000:51,
-                             4200:61,4001:63,4201:65,5001:77,5100:71,5000:73,5101:75,
-                             6000:56,6200:66,6001:66,6201:67,7102:77,7000:77,7101:77,8000:95};
-                    function _tioWmo(code) { return m[code] !== undefined ? m[code] : 2; }
-                    var ht = d.timelines && d.timelines.hourly;
-                    if (ht) ht.forEach(function(h) {
-                        var dt = new Date(h.time);
-                        if (Qt.formatDate(dt, "yyyy-MM-dd") !== dateStr) return;
-                        var v = h.values;
-                        arr.push({
-                            hour:       Qt.formatTime(dt, "HH:mm"),
-                            tempC:      v.temperature,
-                            code:       _tioWmo(v.weatherCode),
-                            windKmh:    v.windSpeed !== undefined ? v.windSpeed * 3.6 : NaN,
-                            windDeg:    v.windDirection !== undefined ? v.windDirection : NaN,
-                            humidity:   v.humidity !== undefined ? Math.round(v.humidity) : NaN,
-                            precipProb: v.precipitationProbability !== undefined ? Math.round(v.precipitationProbability) : NaN,
-                            precipMm:   v.precipitationIntensity !== undefined ? v.precipitationIntensity : NaN
-                        });
-                    });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── StormGlass ────────────────────────────────────────────────────────
-        if (ap === "stormGlass") {
-            var key = service._sgKey(); if (!key) { callback([]); return; }
-            var url = "https://api.stormglass.io/v2/weather/point"
-                + "?lat=" + lat + "&lng=" + lon
-                + "&params=airTemperature,humidity,windSpeed,windDirection,precipitation,cloudCover";
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.setRequestHeader("Authorization", key);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    function _sgV(obj) {
-                        if (obj === undefined || obj === null) return NaN;
-                        if (typeof obj === "number") return obj;
-                        if (obj.sg !== undefined) return obj.sg;
-                        var k = Object.keys(obj); return k.length > 0 ? obj[k[0]] : NaN;
-                    }
-                    function _sgWmo(cc, pr, t) {
-                        cc = isNaN(cc)?0:cc; pr = isNaN(pr)?0:pr; t = isNaN(t)?10:t;
-                        if (pr > 0.1) { if (t<=0) return pr>2?75:pr>0.5?73:71; return pr>7.5?65:pr>2.5?63:61; }
-                        return cc>80?3:cc>50?2:cc>20?1:0;
-                    }
-                    if (d.hours) d.hours.forEach(function(h) {
-                        var dt = new Date(h.time);
-                        if (Qt.formatDate(dt, "yyyy-MM-dd") !== dateStr) return;
-                        var t=_sgV(h.airTemperature), cc=_sgV(h.cloudCover), pr=_sgV(h.precipitation), ws=_sgV(h.windSpeed);
-                        arr.push({
-                            hour:       Qt.formatTime(dt, "HH:mm"),
-                            tempC:      t, code: _sgWmo(cc, pr, t),
-                            windKmh:    !isNaN(ws) ? ws * 3.6 : NaN,
-                            windDeg:    _sgV(h.windDirection),
-                            humidity:   (function(){ var v=_sgV(h.humidity); return !isNaN(v)?Math.round(v):NaN; })(),
-                            precipProb: NaN, precipMm: pr
-                        });
-                    });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── Weatherbit ────────────────────────────────────────────────────────
-        if (ap === "weatherbit") {
-            var key = service._wbKey(); if (!key) { callback([]); return; }
-            var url = "https://api.weatherbit.io/v2.0/forecast/hourly"
-                + "?lat=" + lat + "&lon=" + lon
-                + "&key=" + encodeURIComponent(key) + "&units=M&hours=48";
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    function _wbWmo(code) {
-                        if (!code) return 2;
-                        if (code>=200&&code<=233) return 95; if (code>=300&&code<=302) return 51;
-                        if (code===500) return 61; if (code===501) return 63; if (code===502) return 65;
-                        if (code===511) return 66; if (code>=520&&code<=522) return 80;
-                        if (code===600) return 71; if (code===601) return 73; if (code===602) return 75;
-                        if (code===610||code===611||code===612) return 66;
-                        if (code===621) return 85; if (code===622) return 86; if (code===623) return 77;
-                        if (code>=700&&code<=751) return 45;
-                        if (code===800) return 0; if (code===801) return 1; if (code===802) return 2; if (code>=803) return 3;
-                        return 2;
-                    }
-                    if (d.data) d.data.forEach(function(h) {
-                        var s = (h.timestamp_local || h.datetime || "");
-                        if (s.substring(0, 10) !== dateStr) return;
-                        var dt = new Date(s);
-                        arr.push({
-                            hour:       Qt.formatTime(dt, "HH:mm"),
-                            tempC:      h.temp,
-                            code:       _wbWmo(h.weather ? h.weather.code : undefined),
-                            windKmh:    h.wind_spd !== undefined ? h.wind_spd * 3.6 : NaN,
-                            windDeg:    h.wind_dir !== undefined ? h.wind_dir : NaN,
-                            humidity:   h.rh !== undefined ? Math.round(h.rh) : NaN,
-                            precipProb: h.pop !== undefined ? Math.round(h.pop) : NaN,
-                            precipMm:   h.precip !== undefined ? h.precip : NaN
-                        });
-                    });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
-
-        // ── QWeather ──────────────────────────────────────────────────────────
-        if (ap === "qWeather") {
-            var key = service._qwKey(); if (!key) { callback([]); return; }
-            var base = service._qwHost();
-            var loc  = lon.toFixed(2) + "," + lat.toFixed(2);
-            function _qwHourlySpanHours(ds) {
-                if (!ds)
-                    return 168;
-                var parts = ds.split("-");
-                if (parts.length < 3)
-                    return 168;
-                var year = parseInt(parts[0], 10);
-                var month = parseInt(parts[1], 10) - 1;
-                var day = parseInt(parts[2], 10);
-                if (isNaN(year) || isNaN(month) || isNaN(day))
-                    return 168;
-                var targetEnd = new Date(year, month, day, 23, 59, 59, 999);
-                var diffHours = Math.ceil((targetEnd.getTime() - (new Date()).getTime()) / 3600000);
-                if (diffHours <= 24)
-                    return 24;
-                if (diffHours <= 72)
-                    return 72;
-                return 168;
+        var delivered = false;
+        var sink = {
+            _rows: [],
+            get hourlyData() {
+                return this._rows;
+            },
+            set hourlyData(rows) {
+                this._rows = rows || [];
+                if (delivered)
+                    return;
+                delivered = true;
+                callback(this._rows);
             }
-            var url  = base + "/v7/weather/" + _qwHourlySpanHours(dateStr) + "h?location=" + encodeURIComponent(loc) + "&unit=m";
-            var xhr = new XMLHttpRequest(); xhr.open("GET", url);
-            xhr.setRequestHeader("X-QW-Api-Key", key);
-            xhr.onreadystatechange = function() {
-                if (xhr.readyState !== XMLHttpRequest.DONE) return;
-                if (xhr.status !== 200) { callback([]); return; }
-                try {
-                    var d = JSON.parse(xhr.responseText); var arr = [];
-                    function _qwWmo(code) {
-                        code = parseInt(code, 10); if (isNaN(code)) return 2;
-                        if (code===100||code===150) return 0;
-                        if (code===101||code===102||code===151||code===152) return 2;
-                        if (code===103||code===104||code===153) return 3;
-                        if (code===302||code===303) return 95; if (code===304) return 99;
-                        if (code===300||code===301||code===350||code===351) return 80;
-                        if (code===305||code===309||code===314) return 61;
-                        if (code===306||code===315) return 63;
-                        if (code>=307&&code<=318) return 65; if (code===399) return 63;
-                        if (code===313) return 66;
-                        if (code===400||code===408) return 71; if (code===401||code===409) return 73;
-                        if (code===402||code===403||code===410) return 75;
-                        if (code===404||code===405) return 66;
-                        if (code===406||code===407||code===456||code===457) return 77; if (code===499) return 73;
-                        if (code>=500&&code<=515) return 45; return 2;
-                    }
-                    if (d.code === "200" && d.hourly) d.hourly.forEach(function(h) {
-                        var dt = new Date(h.fxTime);
-                        if (Qt.formatDate(dt, "yyyy-MM-dd") !== dateStr) return;
-                        arr.push({
-                            hour:       Qt.formatTime(dt, "HH:mm"),
-                            tempC:      parseFloat(h.temp),
-                            code:       _qwWmo(h.icon),
-                            windKmh:    parseFloat(h.windSpeed),
-                            windDeg:    parseFloat(h.wind360),
-                            humidity:   parseFloat(h.humidity),
-                            precipProb: h.pop !== undefined && h.pop !== null ? parseFloat(h.pop) : NaN,
-                            precipMm:   h.precip !== undefined && h.precip !== null ? parseFloat(h.precip) : NaN
-                        });
-                    });
-                    callback(arr);
-                } catch(e) { callback([]); }
-            };
-            xhr.send(); return;
-        }
+        };
 
-        callback([]);
+        var proxyService = Object.create(service);
+        proxyService.weatherRoot = sink;
+        proxyService._refreshGen = service._refreshGen;
+        Object.defineProperty(proxyService, "hourlyData", {
+            configurable: true,
+            get: function () { return sink.hourlyData; },
+            set: function (rows) { sink.hourlyData = rows; }
+        });
+
+        try {
+            if (!_p.fetchHourly(ap, proxyService, dateStr)) {
+                delivered = true;
+                callback([]);
+            }
+        } catch (e) {
+            if (!delivered) {
+                delivered = true;
+                callback([]);
+            }
+        }
     }
 
 
@@ -861,13 +503,13 @@ QtObject {
         if (idx > 0 && _refreshGen !== chain._gen) return;
 
         if (idx >= chain.length) {
-            weatherRoot.loading = false;
+            service.loading = false;
             _safetyTimer.stop();
             var names = chain.map(function (p) {
                 return _providerLabel(p);
             });
             service._clearUpdateMetadata();
-            weatherRoot.updateText = i18n("Failed: %1", names.join(", "));
+            service.updateText = i18n("Failed: %1", names.join(", "));
             _failed = [];
             // Still fetch alerts even if all weather providers failed
             _fetchAlertsIfNeeded();
@@ -877,10 +519,10 @@ QtObject {
         var _p = _providers();
         if (!_p) {
             // Providers.qml failed to load — fail this refresh gracefully.
-            weatherRoot.loading = false;
+            service.loading = false;
             _safetyTimer.stop();
             service._clearUpdateMetadata();
-            weatherRoot.updateText = i18n("Failed to load weather providers");
+            service.updateText = i18n("Failed to load weather providers");
             return;
         }
         _p.fetchCurrent(p, service, chain, idx);
@@ -890,16 +532,16 @@ QtObject {
 
     /**
      * Fetches AQI, pollutant concentrations, and pollen from the Open-Meteo
-     * air-quality API and writes them into weatherRoot.
+     * air-quality API and writes them through WeatherService pass-through state.
      * Called by providers that don't supply this data natively.
      */
     function _fetchAirQualityOpenMeteo() {
         var gen = _refreshGen;
-        var r = weatherRoot;
-        var tz = (Plasmoid.configuration.timezone || "").trim();
+        var r = service;
+        var tz = service.timezone;
         var url = "https://air-quality-api.open-meteo.com/v1/air-quality"
-            + "?latitude=" + Plasmoid.configuration.latitude
-            + "&longitude=" + Plasmoid.configuration.longitude
+            + "?latitude=" + service.latitude
+            + "&longitude=" + service.longitude
             + "&current=european_aqi,pm10,pm2_5,carbon_monoxide,nitrogen_dioxide,sulphur_dioxide,ozone"
             + ",alder_pollen,birch_pollen,grass_pollen,mugwort_pollen,olive_pollen,ragweed_pollen"
             + "&timezone=" + encodeURIComponent(tz.length > 0 ? tz : "auto");
@@ -908,13 +550,18 @@ QtObject {
         req.onreadystatechange = function () {
             if (req.readyState !== XMLHttpRequest.DONE) return;
             if (_refreshGen !== gen) return;
-            if (req.status !== 200) return;
+            if (req.status !== 200) {
+                r.aqiDataStaged = null;
+                r.pollenDataStaged = [];
+                return;
+            }
             try {
                 var d = JSON.parse(req.responseText);
                 var c = d.current || {};
                 var aqi = c.european_aqi;
+                var hasAqi = aqi !== undefined && aqi !== null && !isNaN(aqi);
                 var label = "";
-                if (aqi !== undefined) {
+                if (hasAqi) {
                     if      (aqi <= 20)  label = "Good";
                     else if (aqi <= 40)  label = "Fair";
                     else if (aqi <= 60)  label = "Moderate";
@@ -923,14 +570,14 @@ QtObject {
                     else                 label = "Hazardous";
                 }
                 r.aqiDataStaged = {
-                    index: (aqi !== undefined) ? aqi : NaN,
+                    index: hasAqi ? aqi : NaN,
                     label: label,
-                    pm10:  (c.pm10            !== undefined) ? c.pm10            : NaN,
-                    pm2_5: (c.pm2_5           !== undefined) ? c.pm2_5           : NaN,
-                    no2:   (c.nitrogen_dioxide !== undefined) ? c.nitrogen_dioxide : NaN,
-                    so2:   (c.sulphur_dioxide  !== undefined) ? c.sulphur_dioxide  : NaN,
-                    o3:    (c.ozone            !== undefined) ? c.ozone            : NaN,
-                    co:    (c.carbon_monoxide  !== undefined) ? c.carbon_monoxide / 1000.0 : NaN
+                    pm10:  (c.pm10             !== undefined && c.pm10             !== null && !isNaN(c.pm10))             ? c.pm10 : NaN,
+                    pm2_5: (c.pm2_5            !== undefined && c.pm2_5            !== null && !isNaN(c.pm2_5))            ? c.pm2_5 : NaN,
+                    no2:   (c.nitrogen_dioxide !== undefined && c.nitrogen_dioxide !== null && !isNaN(c.nitrogen_dioxide)) ? c.nitrogen_dioxide : NaN,
+                    so2:   (c.sulphur_dioxide  !== undefined && c.sulphur_dioxide  !== null && !isNaN(c.sulphur_dioxide))  ? c.sulphur_dioxide : NaN,
+                    o3:    (c.ozone            !== undefined && c.ozone            !== null && !isNaN(c.ozone))            ? c.ozone : NaN,
+                    co:    (c.carbon_monoxide  !== undefined && c.carbon_monoxide  !== null && !isNaN(c.carbon_monoxide))  ? c.carbon_monoxide / 1000.0 : NaN
                 };
                 var pollenKeys = [
                     { key: "alder",   field: "alder_pollen"   },
@@ -943,10 +590,14 @@ QtObject {
                 var pd = [];
                 pollenKeys.forEach(function (p) {
                     var v = c[p.field];
-                    pd.push({ key: p.key, value: (v !== undefined && v !== null) ? v : NaN });
+                    if (v !== undefined && v !== null && !isNaN(v))
+                        pd.push({ key: p.key, value: v });
                 });
                 r.pollenDataStaged = pd;
-            } catch (e) {}
+            } catch (e) {
+                r.aqiDataStaged = null;
+                r.pollenDataStaged = [];
+            }
         };
         req.send();
     }
@@ -960,10 +611,14 @@ QtObject {
      */
     function _fetchSunTimesOpenMeteo() {
         var gen = _refreshGen;
-        var r = weatherRoot;
-        var tz = (Plasmoid.configuration.timezone || "").trim();
-        var today = Qt.formatDate(new Date(), "yyyy-MM-dd");
-        var url = "https://api.open-meteo.com/v1/forecast" + "?latitude=" + Plasmoid.configuration.latitude + "&longitude=" + Plasmoid.configuration.longitude + "&timezone=" + encodeURIComponent(tz.length > 0 ? tz : "auto") + "&daily=sunrise,sunset" + "&start_date=" + today + "&end_date=" + today;
+        var r = service;
+        var tz = service.timezone;
+        var url = "https://api.open-meteo.com/v1/forecast"
+            + "?latitude=" + service.latitude
+            + "&longitude=" + service.longitude
+            + "&timezone=" + encodeURIComponent(tz.length > 0 ? tz : "auto")
+            + "&forecast_days=1"
+            + "&daily=sunrise,sunset";
         var req = new XMLHttpRequest();
         req.open("GET", url);
         req.onreadystatechange = function () {
@@ -974,10 +629,12 @@ QtObject {
                 return;  // leave "--" in place — better than crashing
             try {
                 var d = JSON.parse(req.responseText);
-                if (r.weatherData && (
+                var currentData = service.weatherDataStaged
+                    || (rootRef ? (rootRef.weatherDataStaged || rootRef.weatherData) : null);
+                if (currentData && (
                     (d.daily && d.daily.sunrise && d.daily.sunrise.length > 0) ||
                     (d.daily && d.daily.sunset  && d.daily.sunset.length  > 0))) {
-                    var patched = Object.assign({}, r.weatherData);
+                    var patched = Object.assign({}, currentData);
                     if (d.daily.sunrise && d.daily.sunrise.length > 0)
                         patched.sunriseTimeText = Qt.formatTime(new Date(d.daily.sunrise[0]), "HH:mm");
                     if (d.daily.sunset && d.daily.sunset.length > 0)

--- a/contents/ui/components/HourlyCardsView.qml
+++ b/contents/ui/components/HourlyCardsView.qml
@@ -1,0 +1,318 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import "../js/iconResolver.js" as IconResolver
+import "../js/weather.js" as W
+
+Item {
+    id: root
+    property var hostRoot
+    property var serviceRoot
+    property var wiFont
+    property var hourlyItems: []
+    property bool autoScrollToCurrent: false
+
+    function _scrollToAnchor() {
+        if (!autoScrollToCurrent || !hourlyItems || hourlyItems.length === 0)
+            return;
+        var targetIndex = -1;
+        for (var index = 0; index < hourlyItems.length; index++) {
+            if (hourlyItems[index].autoScrollTarget === true) {
+                targetIndex = index;
+                break;
+            }
+        }
+        if (targetIndex < 0)
+            return;
+        hourlyList.positionViewAtIndex(targetIndex, ListView.Beginning);
+    }
+
+    ListView {
+        id: hourlyList
+        anchors.fill: parent
+        anchors.margins: 8
+        clip: true
+        orientation: ListView.Horizontal
+        spacing: 6
+        model: root.hourlyItems || []
+        reuseItems: true
+        cacheBuffer: width
+        boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar {
+            policy: ScrollBar.AlwaysOff
+        }
+        ScrollBar.horizontal: ScrollBar {
+            policy: ScrollBar.AsNeeded
+        }
+
+        onModelChanged: scrollTimer.restart()
+        Component.onCompleted: scrollTimer.restart()
+
+        delegate: Rectangle {
+            id: cardDelegate
+            required property var modelData
+            readonly property bool _isSun: modelData.isSunrise === true || modelData.isSunset === true
+
+            width: _isSun ? 70 : root.hostRoot._hourlyCardWidth
+            height: root.hostRoot._hourlyCardHeight
+            radius: 8
+            color: _isSun
+                ? Qt.rgba(root.hostRoot.themeTextColor.r, root.hostRoot.themeTextColor.g, root.hostRoot.themeTextColor.b, 0.04)
+                : Qt.rgba(root.hostRoot.themeTextColor.r, root.hostRoot.themeTextColor.g, root.hostRoot.themeTextColor.b, 0.08)
+            border.color: Qt.rgba(root.hostRoot.themeTextColor.r, root.hostRoot.themeTextColor.g, root.hostRoot.themeTextColor.b, 0.12)
+            border.width: 1
+
+            ColumnLayout {
+                visible: cardDelegate._isSun
+                anchors.centerIn: parent
+                spacing: 6
+
+                WeatherIcon {
+                    Layout.alignment: Qt.AlignHCenter
+                    iconInfo: IconResolver.resolve(
+                        cardDelegate.modelData.isSunrise ? "sunrise" : "sunset",
+                        32,
+                        root.hostRoot.iconsBaseDir,
+                        root.hostRoot.widgetIconTheme === "kde" ? "flat-color" :
+                        (root.hostRoot.widgetIconTheme === "wi-font" || root.hostRoot.widgetIconTheme === "custom" || root.hostRoot.widgetIconTheme === "kde-symbolic") ? "symbolic" : root.hostRoot.widgetIconTheme)
+                    iconSize: 32
+                    iconColor: root.hostRoot.themeTextColor
+                }
+
+                Label {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: cardDelegate.modelData.displayTime || "--"
+                    color: root.hostRoot.themeTextColor
+                    font: root.serviceRoot ? root.serviceRoot.wf(10, true) : Qt.font({ bold: true })
+                }
+            }
+
+            ColumnLayout {
+                visible: !cardDelegate._isSun
+                anchors.fill: parent
+                anchors.margins: 6
+                spacing: 4
+
+                Label {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: cardDelegate.modelData.displayTime || "--"
+                    color: root.hostRoot.themeTextColor
+                    font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                }
+
+                WeatherIcon {
+                    Layout.alignment: Qt.AlignHCenter
+                    iconInfo: root.hostRoot.resolveConditionIcon(cardDelegate.modelData.code || 0, cardDelegate.modelData.isNight === true, root.hostRoot.iconSz)
+                    iconSize: 48
+                }
+
+                Label {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: cardDelegate.modelData.tempText || "--"
+                    color: root.hostRoot.themeTextColor
+                    font: root.serviceRoot ? root.serviceRoot.wf(11, true) : Qt.font({ bold: true })
+                }
+
+                RowLayout {
+                    visible: root.hostRoot._hourlyShowWind
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 4
+
+                    Label {
+                        text: cardDelegate.modelData.windText || "--"
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+
+                    Text {
+                        visible: !isNaN(cardDelegate.modelData.windDeg)
+                        text: W.windDirectionGlyph(cardDelegate.modelData.windDeg)
+                        font.family: root.wiFont && root.wiFont.status === FontLoader.Ready ? root.wiFont.font.family : ""
+                        font.pixelSize: 20
+                        color: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+                }
+
+                RowLayout {
+                    visible: root.hostRoot._hourlyShowPressure
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 3
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("pressure", 24, root.hostRoot.iconsBaseDir, root.hostRoot.itemsIconTheme)
+                        iconSize: 24
+                        iconColor: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.pressureText || "--"
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+                }
+
+                RowLayout {
+                    visible: root.hostRoot._hourlyShowKpIndex
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 3
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("spaceweather", 24, root.hostRoot.iconsBaseDir, root.hostRoot.itemsIconTheme)
+                        iconSize: 24
+                        iconColor: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.kpText || qsTr("No info")
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+                }
+
+                RowLayout {
+                    visible: root.hostRoot._hourlyShowUvIndex
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 3
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("uvindex", 24, root.hostRoot.iconsBaseDir, root.hostRoot.itemsIconTheme)
+                        iconSize: 24
+                        iconColor: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.uvText || "--"
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+                }
+
+                RowLayout {
+                    visible: root.hostRoot._hourlyShowPrecipSum
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 3
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("precipsum", 24, root.hostRoot.iconsBaseDir, root.hostRoot.itemsIconTheme)
+                        iconSize: 24
+                        iconColor: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.precipText || "--"
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+                }
+
+                RowLayout {
+                    visible: root.hostRoot._hourlyShowVisibility
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 3
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("visibility", 24, root.hostRoot.iconsBaseDir, root.hostRoot.itemsIconTheme)
+                        iconSize: 24
+                        iconColor: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.visibilityText || "--"
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+                }
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 3
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("umbrella", 32, root.hostRoot.iconsBaseDir,
+                            root.hostRoot.widgetIconTheme === "kde" ? "flat-color" :
+                            (root.hostRoot.widgetIconTheme === "wi-font" || root.hostRoot.widgetIconTheme === "custom" || root.hostRoot.widgetIconTheme === "kde-symbolic") ? "symbolic" : root.hostRoot.widgetIconTheme)
+                        iconSize: 32
+                        iconColor: root.hostRoot.themeTextColor
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.precipDisplayText || "--"
+                        color: root.hostRoot.themeTextColor
+                        font: root.serviceRoot ? root.serviceRoot.wf(9, false) : Qt.font({})
+                    }
+                }
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: -5
+                    visible: cardDelegate.modelData.precipRateVisible === true
+
+                    WeatherIcon {
+                        iconInfo: IconResolver.resolve("preciprate", 32, root.hostRoot.iconsBaseDir,
+                            root.hostRoot.widgetIconTheme === "kde" ? "flat-color" :
+                            (root.hostRoot.widgetIconTheme === "wi-font" || root.hostRoot.widgetIconTheme === "custom" || root.hostRoot.widgetIconTheme === "kde-symbolic") ? "symbolic" : root.hostRoot.widgetIconTheme)
+                        iconSize: 32
+                        iconColor: root.hostRoot.themeTextColor
+                        opacity: 0.6
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Label {
+                        text: cardDelegate.modelData.precipRateText || "--"
+                        color: root.hostRoot.themeTextColor
+                        opacity: 0.6
+                        font: root.serviceRoot ? root.serviceRoot.wf(8, false) : Qt.font({})
+                    }
+                }
+            }
+        }
+    }
+
+    Timer {
+        id: scrollTimer
+        interval: 0
+        onTriggered: root._scrollToAnchor()
+    }
+
+    NumberAnimation {
+        id: wheelAnimation
+        target: hourlyList
+        property: "contentX"
+        duration: 140
+        easing.type: Easing.OutCubic
+    }
+
+    MouseArea {
+        anchors.fill: hourlyList
+        acceptedButtons: Qt.NoButton
+        onWheel: function(wheel) {
+            if (root.hostRoot._hourlyWheelWantsHorizontal(wheel)) {
+                var delta = wheel.angleDelta.x !== 0 ? wheel.angleDelta.x : root.hostRoot._wheelDeltaX(wheel);
+                var pixelDelta = wheel.angleDelta.x === 0 && wheel.pixelDelta.x !== 0;
+                if (delta === 0) {
+                    delta = wheel.angleDelta.y !== 0 ? wheel.angleDelta.y : root.hostRoot._wheelDeltaY(wheel);
+                    pixelDelta = wheel.angleDelta.y === 0 && wheel.pixelDelta.y !== 0;
+                }
+                var maxX = Math.max(0, hourlyList.contentWidth - hourlyList.width);
+                var targetX = pixelDelta
+                    ? Math.max(0, Math.min(maxX, hourlyList.contentX - delta))
+                    : Math.max(0, Math.min(maxX, hourlyList.contentX - (delta / 120) * root.hostRoot._hourlyCardWidth * 0.8));
+                wheelAnimation.to = targetX;
+                wheelAnimation.restart();
+                wheel.accepted = true;
+            } else {
+                wheel.accepted = root.hostRoot._scrollParentVertically(wheel);
+            }
+        }
+    }
+}

--- a/contents/ui/components/qmldir
+++ b/contents/ui/components/qmldir
@@ -4,3 +4,4 @@ CollapsibleCardHeader 1.0 CollapsibleCardHeader.qml
 ConfigLocationPositionSources 1.0 ConfigLocationPositionSources.qml
 RadarWebEngineView 1.0 RadarWebEngineView.qml
 RadarWebEngineViewLibreWXR 1.0 RadarWebEngineViewLibreWXR.qml
+HourlyCardsView 1.0 HourlyCardsView.qml

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -900,6 +900,155 @@ PlasmoidItem {
         return Qt.formatTime(dateAtUtcOffset(new Date(), utcOffsetMins), Qt.locale().timeFormat(Locale.ShortFormat));
     }
 
+    function _timezoneOffsetLabel(utcOffsetMins) {
+        var offset = _hasNumericValue(utcOffsetMins)
+            ? Math.round(utcOffsetMins)
+            : _displayOffsetFallbackMins(new Date());
+        var sign = offset >= 0 ? "+" : "-";
+        var absOffset = Math.abs(offset);
+        var hours = Math.floor(absOffset / 60);
+        var minutes = absOffset % 60;
+        var hourText = hours < 10 ? "0" + hours : "" + hours;
+        var minuteText = minutes < 10 ? "0" + minutes : "" + minutes;
+        return "UTC" + sign + hourText + ":" + minuteText;
+    }
+
+    function _timezoneOffsetMinsFromLabel(label) {
+        var text = (label || "").trim();
+        var match = /^(?:GMT|UTC)\s*([+-])\s*(\d{1,2})(?::?(\d{2}))?$/i.exec(text);
+        if (!match)
+            return NaN;
+        var sign = match[1] === "-" ? -1 : 1;
+        var hours = parseInt(match[2], 10);
+        var minutes = match[3] ? parseInt(match[3], 10) : 0;
+        if (isNaN(hours) || isNaN(minutes))
+            return NaN;
+        return sign * (hours * 60 + minutes);
+    }
+
+    function _timezoneIanaAbbrev(tzId, utcOffsetMins) {
+        var tz = (tzId || "").trim();
+        if (tz.length === 0)
+            return "";
+        var offset = _hasNumericValue(utcOffsetMins)
+            ? Math.round(utcOffsetMins)
+            : effectiveLocationUtcOffsetMins();
+
+        function inList(list) {
+            return list.indexOf(tz) >= 0;
+        }
+
+        if (inList([
+            "Europe/Amsterdam", "Europe/Andorra", "Europe/Belgrade", "Europe/Berlin", "Europe/Bratislava",
+            "Europe/Brussels", "Europe/Budapest", "Europe/Copenhagen", "Europe/Gibraltar", "Europe/Ljubljana",
+            "Europe/Luxembourg", "Europe/Madrid", "Europe/Malta", "Europe/Monaco", "Europe/Oslo",
+            "Europe/Paris", "Europe/Podgorica", "Europe/Prague", "Europe/Rome", "Europe/San_Marino",
+            "Europe/Sarajevo", "Europe/Skopje", "Europe/Stockholm", "Europe/Tirane", "Europe/Vaduz",
+            "Europe/Vatican", "Europe/Vienna", "Europe/Warsaw", "Europe/Zagreb", "Europe/Zurich"
+        ]))
+            return offset >= 120 ? "CEST" : "CET";
+
+        if (inList(["Europe/Athens", "Europe/Bucharest", "Europe/Helsinki", "Europe/Kiev", "Europe/Riga", "Europe/Sofia", "Europe/Tallinn", "Europe/Vilnius"]))
+            return offset >= 180 ? "EEST" : "EET";
+
+        if (tz === "Europe/London")
+            return offset >= 60 ? "BST" : "GMT";
+
+        if (inList(["America/Detroit", "America/Indiana/Indianapolis", "America/Kentucky/Louisville", "America/Montreal", "America/Nassau", "America/New_York", "America/Toronto"]))
+            return offset >= -240 ? "EDT" : "EST";
+
+        if (inList(["America/Chicago", "America/Indiana/Knox", "America/Managua", "America/Menominee", "America/Mexico_City", "America/Winnipeg"]))
+            return offset >= -300 ? "CDT" : "CST";
+
+        if (inList(["America/Boise", "America/Denver", "America/Edmonton"]))
+            return offset >= -360 ? "MDT" : "MST";
+
+        if (inList(["America/Los_Angeles", "America/Tijuana", "America/Vancouver"]))
+            return offset >= -420 ? "PDT" : "PST";
+
+        if (tz === "America/Anchorage")
+            return offset >= -480 ? "AKDT" : "AKST";
+
+        if (tz === "Pacific/Honolulu")
+            return "HST";
+
+        if (tz === "Asia/Tokyo")
+            return "JST";
+
+        if (tz === "Asia/Seoul")
+            return "KST";
+
+        if (tz === "Asia/Shanghai")
+            return "CST";
+
+        if (tz === "Asia/Hong_Kong")
+            return "HKT";
+
+        if (tz === "Asia/Singapore")
+            return "SGT";
+
+        if (tz === "Asia/Kolkata")
+            return "IST";
+
+        if (inList(["Australia/Canberra", "Australia/Hobart", "Australia/Melbourne", "Australia/Sydney"]))
+            return offset >= 660 ? "AEDT" : "AEST";
+
+        if (tz === "Australia/Adelaide")
+            return offset >= 630 ? "ACDT" : "ACST";
+
+        if (tz === "Australia/Perth")
+            return "AWST";
+
+        if (tz === "Pacific/Auckland")
+            return offset >= 780 ? "NZDT" : "NZST";
+
+        return "";
+    }
+
+    function _normalizedTimezoneShortLabel(rawLabel, utcOffsetMins) {
+        var raw = (rawLabel || "").trim();
+        var offset = _hasNumericValue(utcOffsetMins)
+            ? Math.round(utcOffsetMins)
+            : effectiveLocationUtcOffsetMins();
+        var tzId = (Plasmoid.configuration.timezone || _activeLocTz || "").trim();
+
+        if (raw.length > 0) {
+            if (/^[A-Za-z]{2,6}$/.test(raw))
+                return raw;
+            var parsedOffset = _timezoneOffsetMinsFromLabel(raw);
+            if (_hasNumericValue(parsedOffset)) {
+                var mapped = _timezoneIanaAbbrev(tzId, parsedOffset);
+                return mapped.length > 0 ? mapped : _timezoneOffsetLabel(parsedOffset);
+            }
+        }
+
+        var derived = _timezoneIanaAbbrev(tzId, offset);
+        if (derived.length > 0)
+            return derived;
+        return _timezoneOffsetLabel(offset);
+    }
+
+    function locationTimezoneShortLabel() {
+        var abbr = "";
+        if (weatherDataStaged && typeof weatherDataStaged.locationTimezoneAbbrev === "string")
+            abbr = weatherDataStaged.locationTimezoneAbbrev.trim();
+        else if (weatherData && typeof weatherData.locationTimezoneAbbrev === "string")
+            abbr = weatherData.locationTimezoneAbbrev.trim();
+        return _normalizedTimezoneShortLabel(abbr, effectiveLocationUtcOffsetMins());
+    }
+
+    function shouldShowLocationTimeHint() {
+        if (!hasSelectedTown)
+            return false;
+        return effectiveLocationUtcOffsetMins() !== _displayOffsetFallbackMins(new Date());
+    }
+
+    function locationTimeHintText() {
+        if (!shouldShowLocationTimeHint())
+            return "";
+        return formatNowTimeForOffset(effectiveLocationUtcOffsetMins()) + " " + locationTimezoneShortLabel();
+    }
+
     function locationDateString() {
         return Qt.formatDate(locationNowDate(), "yyyy-MM-dd");
     }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -106,7 +106,7 @@ PlasmoidItem {
     property var weatherDataStaged: null
     property var weatherData: null
     function _applyWeatherData() { weatherData = weatherDataStaged; }
-    onWeatherDataStagedChanged: Qt.callLater(_applyWeatherData)
+    onWeatherDataStagedChanged: _applyWeatherData()
 
     readonly property real   temperatureC:          weatherData ? weatherData.temperatureC          : NaN
     readonly property real   apparentC:             weatherData ? weatherData.apparentC             : NaN
@@ -125,12 +125,12 @@ PlasmoidItem {
     readonly property string sunriseTimeText:       weatherData ? weatherData.sunriseTimeText       : "--"
     readonly property string sunsetTimeText:        weatherData ? weatherData.sunsetTimeText        : "--"
     readonly property var    dailyData:             weatherData ? weatherData.dailyData             : []
-    readonly property real   precipSumMm:           dailyData.length > 0 && !isNaN(dailyData[0].precipMm) ? dailyData[0].precipMm : NaN
+    readonly property real   precipSumMm:           dailyData.length > 0 && _hasNumericValue(dailyData[0].precipMm) ? dailyData[0].precipMm : NaN
 
     property var aqiDataStaged: null
     property var aqiData: null
     function _applyAqiData() { aqiData = aqiDataStaged; }
-    onAqiDataStagedChanged: Qt.callLater(_applyAqiData)
+    onAqiDataStagedChanged: _applyAqiData()
 
     // Inline accessors — callers subscribe to aqiData directly rather than
     // 8 separate reactive properties each adding their own subscriber chain.
@@ -162,13 +162,16 @@ PlasmoidItem {
     property var pollenDataStaged: []
     property var pollenData: []             // [{key, value}] UPI 0–12 per pollen type — set via _applyPollenData
     function _applyPollenData() { pollenData = pollenDataStaged; }
-    onPollenDataStagedChanged: Qt.callLater(_applyPollenData)
+    onPollenDataStagedChanged: _applyPollenData()
     property var spaceWeather: null         // NOAA SWPC data object
     property var spaceWeatherDailyForecast: ({}) // dateStr -> {kp, gScale}, ~3 days ahead
     property var spaceWeatherForecastPeriods: [] // sorted [{startMs, kp, gScale}], 3-hour UTC periods
     property string moonriseTimeText: "--"
     property string moonsetTimeText: "--"
     property var hourlyData: []
+    property var prefetchedHourlyByDate: ({})
+    property var _prefetchedHourlyLoading: ({})
+    property int _prefetchedHourlyGeneration: 0
     property int panelScrollIndex: 0
     property string updateText: ""
 
@@ -219,13 +222,16 @@ PlasmoidItem {
     property bool hasSelectedTown: false
     function _updateHasSelectedTown() {
         var name = Plasmoid.configuration.locationName || _activeLocName || "";
+        var lat = Plasmoid.configuration.latitude !== 0 ? Plasmoid.configuration.latitude : _activeLocLat;
+        var lon = Plasmoid.configuration.longitude !== 0 ? Plasmoid.configuration.longitude : _activeLocLon;
+        var hasCoords = !isNaN(lat) && !isNaN(lon) && (lat !== 0.0 || lon !== 0.0);
         var next;
         if (name.trim().length > 0) {
             next = true;
-        } else if (Plasmoid.configuration.autoDetectLocation) {
-            var lat = Plasmoid.configuration.latitude !== 0 ? Plasmoid.configuration.latitude : _activeLocLat;
-            var lon = Plasmoid.configuration.longitude !== 0 ? Plasmoid.configuration.longitude : _activeLocLon;
-            next = (lat !== 0.0 || lon !== 0.0);
+        } else if (hasCoords) {
+            // Keep the widget live when a valid manual location exists but the
+            // display name has not propagated yet during startup.
+            next = true;
         } else {
             next = false;
         }
@@ -322,7 +328,7 @@ PlasmoidItem {
 
     WeatherService {
         id: weatherService
-        weatherRoot: root
+        rootRef: root
     }
 
     // Each notification category gets its own Notification instance.
@@ -644,6 +650,115 @@ PlasmoidItem {
         req.send();
     }
 
+    function _sameConfiguredCoords(lat, lon) {
+        return Math.abs((Plasmoid.configuration.latitude || 0) - lat) < 0.000001
+            && Math.abs((Plasmoid.configuration.longitude || 0) - lon) < 0.000001;
+    }
+
+    function _sameLocationCoords(latA, lonA, latB, lonB) {
+        return Math.abs((latA || 0) - (latB || 0)) < 0.000001
+            && Math.abs((lonA || 0) - (lonB || 0)) < 0.000001;
+    }
+
+    function _syncCurrentLocationRecord() {
+        var loc = {
+            name: Plasmoid.configuration.locationName || root._activeLocName || "",
+            lat: Plasmoid.configuration.latitude || root._activeLocLat || 0,
+            lon: Plasmoid.configuration.longitude || root._activeLocLon || 0,
+            altitude: Plasmoid.configuration.altitude !== undefined ? Plasmoid.configuration.altitude : root._activeLocAlt,
+            timezone: Plasmoid.configuration.timezone || root._activeLocTz || "",
+            countryCode: (Plasmoid.configuration.countryCode || root._activeLocCC || "").toUpperCase()
+        };
+        Plasmoid.configuration.activeLocation = JSON.stringify(loc);
+        try {
+            var raw = Plasmoid.configuration.savedLocations || "[]";
+            var arr = JSON.parse(raw);
+            if (!Array.isArray(arr))
+                return;
+            var changed = false;
+            for (var i = 0; i < arr.length; i++) {
+                var item = arr[i];
+                if (!_sameLocationCoords(item.lat, item.lon, loc.lat, loc.lon))
+                    continue;
+                if ((item.name || "") !== loc.name) { item.name = loc.name; changed = true; }
+                if ((item.timezone || "") !== loc.timezone) { item.timezone = loc.timezone; changed = true; }
+                if (((item.countryCode || "").toUpperCase()) !== loc.countryCode) { item.countryCode = loc.countryCode; changed = true; }
+                if (loc.altitude !== undefined && item.altitude !== loc.altitude) { item.altitude = loc.altitude; changed = true; }
+            }
+            if (changed)
+                Plasmoid.configuration.savedLocations = JSON.stringify(arr);
+        } catch (e) {}
+    }
+
+    function _patchActiveLocationMeta(fields) {
+        try {
+            var raw = Plasmoid.configuration.activeLocation || "{}";
+            var o = JSON.parse(raw);
+            if (!o || typeof o !== "object")
+                return;
+            if (!_sameConfiguredCoords(o.lat || 0, o.lon || 0))
+                return;
+            for (var key in fields)
+                o[key] = fields[key];
+            Plasmoid.configuration.activeLocation = JSON.stringify(o);
+        } catch (e) {}
+    }
+
+    function _refreshLocationMetadata(lat, lon) {
+        if (isNaN(lat) || isNaN(lon) || (lat === 0 && lon === 0))
+            return;
+
+        var metaReq = new XMLHttpRequest();
+        metaReq.open("GET", "https://api.open-meteo.com/v1/forecast?latitude="
+            + encodeURIComponent(lat)
+            + "&longitude=" + encodeURIComponent(lon)
+            + "&current=temperature_2m&timezone=auto");
+        metaReq.onreadystatechange = function () {
+            if (metaReq.readyState !== XMLHttpRequest.DONE)
+                return;
+            if (metaReq.status !== 200 || !_sameConfiguredCoords(lat, lon))
+                return;
+            try {
+                var meta = JSON.parse(metaReq.responseText);
+                if (meta.timezone && meta.timezone.length > 0 && Plasmoid.configuration.timezone !== meta.timezone) {
+                    Plasmoid.configuration.timezone = meta.timezone;
+                    root._activeLocTz = meta.timezone;
+                    _patchActiveLocationMeta({ timezone: meta.timezone });
+                }
+                _syncCurrentLocationRecord();
+            } catch (e) {}
+        };
+        metaReq.send();
+
+        var req = new XMLHttpRequest();
+        var lang = Qt.locale().name.split("_")[0];
+        var acceptLang = (lang.length > 0) ? lang + ",en;q=0.8" : "en";
+        req.open("GET", "https://nominatim.openstreetmap.org/reverse"
+            + "?format=jsonv2&zoom=10&addressdetails=1"
+            + "&accept-language=" + acceptLang
+            + "&lat=" + encodeURIComponent(lat)
+            + "&lon=" + encodeURIComponent(lon));
+        req.setRequestHeader("User-Agent", "AdvancedWeatherWidget/1.0 (KDE Plasma plasmoid)");
+        req.onreadystatechange = function () {
+            if (req.readyState !== XMLHttpRequest.DONE)
+                return;
+            if (req.status !== 200 || !_sameConfiguredCoords(lat, lon))
+                return;
+            try {
+                var data = JSON.parse(req.responseText);
+                var a = data && data.address ? data.address : {};
+                var cc = (a.country_code || "").toUpperCase();
+                if (cc.length > 0 && Plasmoid.configuration.countryCode !== cc) {
+                    Plasmoid.configuration.countryCode = cc;
+                    root._activeLocCC = cc;
+                    _patchActiveLocationMeta({ countryCode: cc });
+                }
+                _syncCurrentLocationRecord();
+            } catch (e) {}
+        };
+        req.send();
+    }
+
     /** Set to true around a batch location-config write to suppress intermediate debounce restarts. */
     property bool _batchingLocation: false
 
@@ -669,9 +784,11 @@ PlasmoidItem {
         Plasmoid.configuration.latitude      = loc.lat         || 0;
         Plasmoid.configuration.longitude     = loc.lon         || 0;
         if (loc.altitude  !== undefined) Plasmoid.configuration.altitude    = loc.altitude;
-        if (loc.timezone)               Plasmoid.configuration.timezone     = loc.timezone;
-        if (loc.countryCode)            Plasmoid.configuration.countryCode  = loc.countryCode;
+        Plasmoid.configuration.timezone     = loc.timezone    || "";
+        Plasmoid.configuration.countryCode  = (loc.countryCode || "").toUpperCase();
         _batchingLocation = false;
+        _syncCurrentLocationRecord();
+        locationMetadataRefreshDebounce.restart();
         refreshDebounce.restart();
     }
 
@@ -697,6 +814,9 @@ PlasmoidItem {
      *  force=true (manual refresh button) also bypasses the space weather throttle. */
     function refreshWeather(force) {
         refreshDebounce.stop();
+        _prefetchedHourlyGeneration++;
+        prefetchedHourlyByDate = {};
+        _prefetchedHourlyLoading = {};
         weatherService.refreshNow(force === true);
     }
 
@@ -710,13 +830,165 @@ PlasmoidItem {
         weatherService.fetchHourlyForDateDirect(dateStr, callback);
     }
 
+    function prefetchedHourlyForDate(dateStr) {
+        if (!dateStr)
+            return null;
+        return Object.prototype.hasOwnProperty.call(prefetchedHourlyByDate, dateStr)
+            ? prefetchedHourlyByDate[dateStr]
+            : null;
+    }
+
+    function isHourlyPrefetchInFlight(dateStr) {
+        return !!(dateStr && _prefetchedHourlyLoading[dateStr]);
+    }
+
+    function prefetchHourlyForDate(dateStr) {
+        if (!hasSelectedTown || !dateStr)
+            return;
+        if (Object.prototype.hasOwnProperty.call(prefetchedHourlyByDate, dateStr) || _prefetchedHourlyLoading[dateStr])
+            return;
+
+        var generation = _prefetchedHourlyGeneration;
+        var loading = Object.assign({}, _prefetchedHourlyLoading);
+        loading[dateStr] = true;
+        _prefetchedHourlyLoading = loading;
+
+        fetchHourlyForDateDirect(dateStr, function(rows) {
+            if (generation !== _prefetchedHourlyGeneration)
+                return;
+            var loadDone = Object.assign({}, _prefetchedHourlyLoading);
+            delete loadDone[dateStr];
+            _prefetchedHourlyLoading = loadDone;
+
+            var cached = Object.assign({}, prefetchedHourlyByDate);
+            cached[dateStr] = rows || [];
+            prefetchedHourlyByDate = cached;
+        });
+    }
+
+    function _displayOffsetFallbackMins(sourceDate) {
+        var base = sourceDate || new Date();
+        return -base.getTimezoneOffset();
+    }
+
+    function effectiveLocationUtcOffsetMins() {
+        if (weatherDataStaged && _hasNumericValue(weatherDataStaged.locationUtcOffsetMins))
+            return weatherDataStaged.locationUtcOffsetMins;
+        if (weatherData && _hasNumericValue(weatherData.locationUtcOffsetMins))
+            return weatherData.locationUtcOffsetMins;
+        return _displayOffsetFallbackMins(new Date());
+    }
+
+    function dateAtUtcOffset(sourceDate, utcOffsetMins) {
+        var base = sourceDate || new Date();
+        var targetOffset = _hasNumericValue(utcOffsetMins)
+            ? utcOffsetMins
+            : _displayOffsetFallbackMins(base);
+        return new Date(base.getTime() + (targetOffset + base.getTimezoneOffset()) * 60000);
+    }
+
+    function locationNowDate() {
+        return dateAtUtcOffset(new Date(), effectiveLocationUtcOffsetMins());
+    }
+
+    function locationNowMins() {
+        var now = locationNowDate();
+        return now.getHours() * 60 + now.getMinutes();
+    }
+
+    function formatNowTimeForOffset(utcOffsetMins) {
+        return Qt.formatTime(dateAtUtcOffset(new Date(), utcOffsetMins), Qt.locale().timeFormat(Locale.ShortFormat));
+    }
+
+    function locationDateString() {
+        return Qt.formatDate(locationNowDate(), "yyyy-MM-dd");
+    }
+
+    function dateFromYmd(dateStr) {
+        if (!dateStr)
+            return null;
+        var parts = dateStr.split("-");
+        if (parts.length !== 3)
+            return null;
+        var year = parseInt(parts[0], 10);
+        var month = parseInt(parts[1], 10);
+        var day = parseInt(parts[2], 10);
+        if (isNaN(year) || isNaN(month) || isNaN(day))
+            return null;
+        return new Date(year, month - 1, day, 12, 0, 0, 0);
+    }
+
+    function dayNameForDateStr(dateStr, format) {
+        var d = dateFromYmd(dateStr);
+        if (!d)
+            return "";
+        return Qt.locale().dayName(d.getDay(), format || Locale.LongFormat);
+    }
+
+    function formatDateStrForDisplay(dateStr, format) {
+        var d = dateFromYmd(dateStr);
+        if (!d)
+            return "";
+        var fmt = format;
+        if (fmt === undefined || fmt === null || fmt === "")
+            fmt = Qt.locale().dateFormat(Locale.ShortFormat);
+        return Qt.formatDate(d, fmt);
+    }
+
+    function locationDateTimeToEpoch(dateStr, hhmm, utcOffsetMins) {
+        if (!dateStr || !hhmm || hhmm.length < 4)
+            return NaN;
+        var d = dateFromYmd(dateStr);
+        if (!d)
+            return NaN;
+        var parts = hhmm.split(":");
+        if (parts.length < 2)
+            return NaN;
+        var hour = parseInt(parts[0], 10);
+        var minute = parseInt(parts[1], 10);
+        if (isNaN(hour) || isNaN(minute))
+            return NaN;
+        var offset = _hasNumericValue(utcOffsetMins)
+            ? utcOffsetMins
+            : effectiveLocationUtcOffsetMins();
+        return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), hour, minute, 0, 0) - offset * 60000;
+    }
+
+    function firstForecastDataIndex(includeToday) {
+        if (!dailyData || dailyData.length === 0)
+            return 0;
+        var todayStr = locationDateString();
+        var base = 0;
+        var foundToday = false;
+        if (todayStr.length > 0) {
+            for (var i = 0; i < dailyData.length; i++) {
+                if ((dailyData[i].dateStr || "") === todayStr) {
+                    base = i;
+                    foundToday = true;
+                    break;
+                }
+            }
+        }
+        if (includeToday === false && foundToday)
+            base += 1;
+        return Math.max(0, Math.min(base, dailyData.length));
+    }
+
+    function forecastDisplayCount(includeToday, maxDays) {
+        if (!dailyData || dailyData.length === 0)
+            return 0;
+        var base = firstForecastDataIndex(includeToday);
+        var limit = Math.min(maxDays || dailyData.length, dailyData.length - base);
+        return Math.max(0, limit);
+    }
+
     // ══════════════════════════════════════════════════════════════════════
     // Value formatters — delegate pure math to weather.js, inject config here
     // ══════════════════════════════════════════════════════════════════════
 
     // ── Date/time item formatter ─────────────────────────────────────────────
     function _formatItemDateTime(dateFmt, timeFmt) {
-        var now = new Date();
+        var now = locationNowDate();
         var dateStr = "";
         if (dateFmt === "locale-long")       dateStr = now.toLocaleDateString(Qt.locale(), Locale.LongFormat);
         else if (dateFmt === "locale-short") dateStr = now.toLocaleDateString(Qt.locale(), Locale.ShortFormat);
@@ -735,7 +1007,6 @@ PlasmoidItem {
         return Plasmoid.configuration.temperatureUnit || "C";
     }
     function tempValue(celsius, context) {
-        if (W.isNotSupported(celsius)) return i18n("Not supported");
         var unit = _tempUnit();
         var primary = W.formatTemp(celsius, unit, Plasmoid.configuration.roundValues, Plasmoid.configuration.showTempUnit);
         if (!Plasmoid.configuration.dualTempEnabled) return primary;
@@ -768,7 +1039,6 @@ PlasmoidItem {
         return Plasmoid.configuration.pressureUnit || "hPa";
     }
     function pressureValue(hpa) {
-        if (W.isNotSupported(hpa)) return i18n("Not supported");
         if (isNaN(hpa) || hpa === null || hpa === undefined) return "--";
         var unit = _pressureUnit();
         return W.formatPressureValue(hpa, unit) + " " + i18n(W.pressureUnitLabel(unit));
@@ -780,25 +1050,26 @@ PlasmoidItem {
         return (_tempUnit() === "F");
     }
 
+    function _hasNumericValue(value) {
+        return value !== null && value !== undefined && !isNaN(value);
+    }
+
     function precipValue(mmh) {
-        if (W.isNotSupported(mmh)) return i18n("Not supported");
-        if (isNaN(mmh)) return "--";
+        if (!_hasNumericValue(mmh)) return "--";
         if (_isImperial())
             return (mmh / 25.4).toFixed(2) + " " + i18n("in/h");
         return mmh.toFixed(1) + " " + i18n("mm/h");
     }
 
     function precipSumText(mm) {
-        if (W.isNotSupported(mm)) return i18n("Not supported");
-        if (isNaN(mm)) return "--";
+        if (!_hasNumericValue(mm)) return "--";
         if (_isImperial())
             return (mm / 25.4).toFixed(2) + " " + i18n("in");
         return mm.toFixed(1) + " " + i18n("mm");
     }
 
     function visibilityValue(km) {
-        if (W.isNotSupported(km)) return i18n("Not supported");
-        if (isNaN(km)) return "--";
+        if (!_hasNumericValue(km)) return "--";
         if (_isImperial())
             return (km * 0.621371).toFixed(1) + " " + i18n("mi");
         return km.toFixed(1) + " " + i18n("km");
@@ -825,8 +1096,7 @@ PlasmoidItem {
     }
 
     function uvIndexText(uv) {
-        if (W.isNotSupported(uv)) return i18n("Not supported");
-        if (isNaN(uv)) return "--";
+        if (!_hasNumericValue(uv)) return "--";
         var v = Math.round(uv * 10) / 10;
         if (v <= 2) return v + " (" + i18n("Low") + ")";
         if (v <= 5) return v + " (" + i18n("Moderate") + ")";
@@ -837,7 +1107,7 @@ PlasmoidItem {
 
     function airQualityText() {
         var aqi = airQualityIndex();
-        if (isNaN(aqi)) return "--";
+        if (!_hasNumericValue(aqi)) return "--";
         // EU AQI band
         var label = "";
         var square = "";
@@ -867,7 +1137,7 @@ PlasmoidItem {
         var best = null;
         for (var i = 0; i < pollenData.length; i++) {
             var p = pollenData[i];
-            if (isNaN(p.value) || p.value === null) continue;
+            if (!_hasNumericValue(p.value)) continue;
             if (!best || p.value > best.value) best = p;
         }
         if (!best) return "--";
@@ -895,12 +1165,12 @@ PlasmoidItem {
      */
     function spaceWeatherText() {
         var sw = spaceWeather;
-        if (!sw || isNaN(sw.kp)) return "--";
+        if (!sw || !_hasNumericValue(sw.kp)) return "--";
         return "Kp " + sw.kp.toFixed(1) + " · " + (sw.gScale || "G0");
     }
 
     function snowDepthText(cm) {
-        if (isNaN(cm)) return "--";
+        if (!_hasNumericValue(cm)) return "--";
         if (_isImperial())
             return (cm / 2.54).toFixed(1) + " " + i18n("in");
         return cm.toFixed(1) + " " + i18n("cm");
@@ -1073,9 +1343,8 @@ PlasmoidItem {
         return nowM >= t;
     }
 
-    function _alertColorAllowed(color, severity) {
+    function _alertColorAllowed(color) {
         var c = (color || "").toLowerCase();
-        var s = (severity || "").toLowerCase();
         // Backward-compatible fallback to old minSeverity if new switches are absent.
         var hasSwitches = (Plasmoid.configuration.alertNotificationsYellowEnabled !== undefined)
             && (Plasmoid.configuration.alertNotificationsOrangeEnabled !== undefined)
@@ -1089,12 +1358,6 @@ PlasmoidItem {
                 return p >= 1;
             return p >= 2;
         }
-        // Extreme is its own "purple" tier — the parsers map it to color "red",
-        // so distinguish it by severity here. When the purple switch is absent
-        // (older config), fall through to the red switch so extreme alerts are
-        // never silently dropped.
-        if (s === "extreme" && Plasmoid.configuration.alertNotificationsPurpleEnabled !== undefined)
-            return Plasmoid.configuration.alertNotificationsPurpleEnabled === true;
         if (c === "red")
             return Plasmoid.configuration.alertNotificationsRedEnabled === true;
         if (c === "orange")
@@ -1195,13 +1458,9 @@ PlasmoidItem {
         return (s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     }
 
-    /** Maps an alert severity/color to a colored-circle emoji — KDE notification
-     *  bodies strip <font color>, but emoji glyphs keep their own color.
-     *  Extreme gets its own purple marker so it's visually distinct from
-     *  Severe (both of which the parsers map to color "red"). */
-    function _alertSeverityEmoji(color, severity) {
-        var s = (severity || "").toLowerCase();
-        if (s === "extreme") return "🟣"; // 🟣 purple — Extreme
+    /** Maps an alert severity color to a colored-circle emoji — KDE notification
+     *  bodies strip <font color>, but emoji glyphs keep their own color. */
+    function _alertSeverityEmoji(color) {
         var c = (color || "").toLowerCase();
         if (c === "red")    return "🔴"; // 🔴
         if (c === "orange") return "🟠"; // 🟠
@@ -1209,31 +1468,14 @@ PlasmoidItem {
         return "";
     }
 
-    /** Translatable, uppercased severity label. Maps the CAP severity enum
-     *  (Extreme/Severe/Moderate/Minor/Unknown) and the color fallbacks
-     *  (red/orange/yellow/green) to localized strings; unknown values fall
-     *  back to the raw string, uppercased. */
-    function _alertSeverityLabel(severity) {
-        var s = (severity || "").trim().toLowerCase();
-        switch (s) {
-        case "extreme":              return i18nc("Alert severity", "EXTREME");
-        case "severe":  case "red":  return i18nc("Alert severity", "SEVERE");
-        case "moderate": case "orange": return i18nc("Alert severity", "MODERATE");
-        case "minor":   case "yellow": return i18nc("Alert severity", "MINOR");
-        case "unknown":              return i18nc("Alert severity", "UNKNOWN");
-        case "green":                return i18nc("Alert severity", "MINIMAL");
-        }
-        return (severity || "").toUpperCase();
-    }
-
     /** Notification body: severity, headline, effective range, instruction, provider. */
     function _alertNotificationBody(a) {
         var lines = [];
+        var emoji = _alertSeverityEmoji(a.color);
         var severity = (a.severity || a.color || "").trim();
-        var emoji = _alertSeverityEmoji(a.color, a.severity);
         if (severity.length > 0) {
             var marker = emoji.length > 0 ? (emoji + " ") : "";
-            lines.push(i18n("<b>Severity:</b> %1%2", marker, _escapeHtml(_alertSeverityLabel(severity))));
+            lines.push(i18n("<b>Severity:</b> %1%2", marker, _escapeHtml(severity.toUpperCase())));
         }
         lines.push(i18n("<b>Headline:</b> %1", _escapeHtml(a.displayName || a.headline || i18n("Weather alert"))));
         var range = _alertEffectiveRangeText(a);
@@ -1411,7 +1653,7 @@ PlasmoidItem {
             var a = alerts[i];
             if (!_isAlertActiveNow(a, now))
                 continue;
-            if (!_alertColorAllowed(a.color, a.severity))
+            if (!_alertColorAllowed(a.color))
                 continue;
             if (!_alertTypeEnabled(a.awarenessType))
                 continue;
@@ -1584,9 +1826,7 @@ PlasmoidItem {
     }
 
     function _hourSampleEpoch(dateStr, hhmm) {
-        if (!dateStr || !hhmm || hhmm.length < 4)
-            return NaN;
-        return new Date(dateStr + "T" + hhmm + ":00").getTime();
+        return locationDateTimeToEpoch(dateStr, hhmm, locationUtcOffsetMins);
     }
 
     /** Finds the next start/end transition for a boolean sample field ("wet" or "snow").
@@ -1752,8 +1992,8 @@ PlasmoidItem {
         if (!dailyData || dailyData.length === 0)
             return;
         var d = dailyData[0];
-        var uvMax = (d.uvMax !== undefined && !isNaN(d.uvMax)) ? d.uvMax : uvIndex;
-        if (isNaN(uvMax))
+        var uvMax = _hasNumericValue(d.uvMax) ? d.uvMax : uvIndex;
+        if (!_hasNumericValue(uvMax))
             return;
         var todayStr = d.dateStr || Qt.formatDate(now, "yyyy-MM-dd");
         var trend = _trendText(uvMax, Plasmoid.configuration.notificationUvLastValue,
@@ -1798,9 +2038,9 @@ PlasmoidItem {
         // "Will be" = today's outlook, so prefer the NOAA daily forecast max;
         // the current observed Kp is only a fallback when the forecast feed failed.
         var fc = kpForecastForDate(todayStr);
-        var kpVal = (fc && !isNaN(fc.kp)) ? fc.kp : (sw && !isNaN(sw.kp) ? sw.kp : NaN);
+        var kpVal = (fc && _hasNumericValue(fc.kp)) ? fc.kp : (sw && _hasNumericValue(sw.kp) ? sw.kp : NaN);
         var gVal = (fc && fc.gScale) ? fc.gScale : ((sw && sw.gScale) ? sw.gScale : "G0");
-        if (isNaN(kpVal))
+        if (!_hasNumericValue(kpVal))
             return;
         var trend = _trendText(kpVal, Plasmoid.configuration.notificationSpaceWeatherLastKp,
             Plasmoid.configuration.notificationSpaceWeatherLastDate, todayStr);
@@ -2051,8 +2291,7 @@ PlasmoidItem {
         if (isDay >= 0)
             return isDay === 0;
         // Fallback: derive from stored sunrise/sunset times.
-        var now = new Date();
-        var nowMins = now.getHours() * 60 + now.getMinutes();
+        var nowMins = locationNowMins();
         function parseMins(t) {
             if (!t || t === "--")
                 return -1;
@@ -2121,6 +2360,11 @@ PlasmoidItem {
             weatherService._safetyTimer.stop();
             if (weatherData && !isNaN(weatherData.temperatureC))
                 _computeMoonTimes();
+            if (dailyData && dailyData.length > 0) {
+                var firstForecastIndex = firstForecastDataIndex(Plasmoid.configuration.forecastShowToday !== false);
+                if (firstForecastIndex >= 0 && firstForecastIndex < dailyData.length)
+                    prefetchHourlyForDate(dailyData[firstForecastIndex].dateStr || "");
+            }
             _refreshNotificationRainWindowIfNeeded(true);
             _evaluateNotifications();
         }
@@ -2210,7 +2454,7 @@ PlasmoidItem {
             var mode = Plasmoid.configuration.panelSunTimesMode || "upcoming";
             if (mode === "sunset")
                 return "\uF052";
-            var nowMins = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+            var nowMins = locationNowMins();
             var riseMins = parseSunTimeMins(sunriseTimeText);
             var setMins = parseSunTimeMins(sunsetTimeText);
             if (mode === "upcoming") {
@@ -2312,7 +2556,7 @@ PlasmoidItem {
 
             if (tok === "suntimes") {
                 var mode2 = Plasmoid.configuration.panelSunTimesMode || "upcoming";
-                var nowM2 = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+                var nowM2 = locationNowMins();
                 var riseM2 = parseSunTimeMins(sunriseTimeText);
                 var setM2 = parseSunTimeMins(sunsetTimeText);
                 var useSet2 = (mode2 === "sunset") || (mode2 === "upcoming" && riseM2 >= 0 && nowM2 >= riseM2 && (setM2 < 0 || nowM2 < setM2));
@@ -2396,7 +2640,7 @@ PlasmoidItem {
         if (mode === "sunrise") return "suntimes-sunrise";
         if (mode === "both") return "suntimes-sunrise"; // CompactView handles both-mode split
         // "upcoming": pick based on current time
-        var nowM = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+        var nowM = locationNowMins();
         var riseM = parseSunTimeMins(sunriseTimeText);
         var setM = parseSunTimeMins(sunsetTimeText);
         var useSet = (riseM >= 0 && nowM >= riseM && (setM < 0 || nowM < setM));
@@ -2405,7 +2649,7 @@ PlasmoidItem {
 
     /** Returns "rise" or "set" depending on which moon event is next */
     function _moonUpcoming() {
-        var nowM = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+        var nowM = locationNowMins();
         var riseM = parseSunTimeMins(moonriseTimeText);
         var setM = parseSunTimeMins(moonsetTimeText);
         if (riseM >= 0 && nowM < riseM) return "rise";
@@ -2452,7 +2696,7 @@ PlasmoidItem {
             return moonPhaseLabel();
         }
         if (tok === "suntimes") {
-            var nowMins = (new Date()).getHours() * 60 + (new Date()).getMinutes();
+            var nowMins = locationNowMins();
             var riseMins = parseSunTimeMins(sunriseTimeText);
             var setMins = parseSunTimeMins(sunsetTimeText);
             if (mode === "upcoming") {
@@ -2592,6 +2836,13 @@ PlasmoidItem {
         }
     }
 
+    Timer {
+        id: locationMetadataRefreshDebounce
+        interval: 200
+        repeat: false
+        onTriggered: _refreshLocationMetadata(_locLat(), _locLon())
+    }
+
     // Persists location to KConfig after popup closes — avoids blocking KConfig
     // D-Bus writes on the UI thread during the location-switch click animation.
     Timer {
@@ -2660,6 +2911,19 @@ PlasmoidItem {
             }
         } catch(e) {}
         _updateHasSelectedTown();
+        if (root.hasSelectedTown)
+            _syncCurrentLocationRecord();
+        // Some Plasma setups hydrate individual configuration keys a tick later
+        // than the applet object itself. Re-check once the event loop settles so
+        // manual locations become visible before the first real refresh.
+        Qt.callLater(function() {
+            root._updateHasSelectedTown();
+            if (root.hasSelectedTown)
+                locationMetadataRefreshDebounce.restart();
+            refreshDebounce.restart();
+        });
+        if (root.hasSelectedTown)
+            locationMetadataRefreshDebounce.restart();
         refreshDebounce.restart();
         // Restore the once-per-day "already sent" keys BEFORE the first evaluation
         // so a plasmashell restart doesn't re-fire daily notifications already
@@ -2698,17 +2962,26 @@ PlasmoidItem {
         function onLocationNameChanged() {
             root._updateHasSelectedTown();
             root.weatherAlerts = [];
-            if (!root._batchingLocation) refreshDebounce.restart();
+            if (!root._batchingLocation) {
+                locationMetadataRefreshDebounce.restart();
+                refreshDebounce.restart();
+            }
         }
         function onLatitudeChanged() {
             root._pendingRainWindowRefresh = true;
             root.weatherAlerts = [];
-            if (!root._batchingLocation) refreshDebounce.restart();
+            if (!root._batchingLocation) {
+                locationMetadataRefreshDebounce.restart();
+                refreshDebounce.restart();
+            }
         }
         function onLongitudeChanged() {
             root._pendingRainWindowRefresh = true;
             root.weatherAlerts = [];
-            if (!root._batchingLocation) refreshDebounce.restart();
+            if (!root._batchingLocation) {
+                locationMetadataRefreshDebounce.restart();
+                refreshDebounce.restart();
+            }
         }
         function onTimezoneChanged() {
             root._pendingRainWindowRefresh = true;

--- a/contents/ui/providers/alerts.js
+++ b/contents/ui/providers/alerts.js
@@ -73,7 +73,7 @@ var _isoToSlug = {
  * Tries NWS for US, MeteoAlarm for Europe, falls back to met.no MetAlerts.
  */
 function fetchAlerts(service) {
-    var r = service.weatherRoot;
+    var r = service;
     var isoCode = (service.countryCode || "").toUpperCase();
 
     // US locations: use NWS alerts API
@@ -129,7 +129,7 @@ function _looksLikeUS(lat, lon) {
 
 function _resolveCountryThenFetch(service) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;  // FIX: r was undefined here, causing silent failure
+    var r = service;  // FIX: r was undefined here, causing silent failure
     var lat = service.latitude;
     var lon = service.longitude;
     if (!lat || !lon) return;
@@ -192,7 +192,7 @@ function _resolveCountryThenFetch(service) {
 
 function _fetchMeteoAlarm(service, slug, callback, prefetchedTerms) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var feedUrl = "https://feeds.meteoalarm.org/api/v1/warnings/feeds-" + slug;
 
     // Run feed fetch and local-name lookup in parallel
@@ -615,7 +615,7 @@ function _haversineKm(lat1, lon1, lat2, lon2) {
 
 function _fetchMetNo(service) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var url = "https://api.met.no/weatherapi/metalerts/2.0/current.json"
         + "?lat=" + service.latitude
         + "&lon=" + service.longitude
@@ -715,7 +715,7 @@ function _parseMetNoAlerts(data) {
  */
 function _fetchNws(service) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var lat = parseFloat(service.latitude);
     var lon = parseFloat(service.longitude);
     if (isNaN(lat) || isNaN(lon)) {

--- a/contents/ui/providers/metNo.js
+++ b/contents/ui/providers/metNo.js
@@ -201,6 +201,10 @@ function fetchHourly(service, W, dateStr) {
                         windDeg: det.wind_from_direction !== undefined
                             ? det.wind_from_direction : NaN,
                         humidity: det.relative_humidity,
+                        pressureHpa: det.air_pressure_at_sea_level !== undefined
+                            ? det.air_pressure_at_sea_level : NaN,
+                        uvIndex: det.ultraviolet_index_clear_sky !== undefined
+                            ? det.ultraviolet_index_clear_sky : NaN,
                         precipProb: (ts.data && ts.data.next_1_hours
                             && ts.data.next_1_hours.details
                             && ts.data.next_1_hours.details.probability_of_precipitation !== undefined)

--- a/contents/ui/providers/metNo.js
+++ b/contents/ui/providers/metNo.js
@@ -37,7 +37,7 @@ function _calcDewPoint(T, rh) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var alt = service.altitude;
     var url = "https://api.met.no/weatherapi/locationforecast/2.0/complete?lat="
         + encodeURIComponent(service.latitude)
@@ -161,7 +161,7 @@ function fetchCurrent(service, W, chain, idx) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var alt = service.altitude;
     var url = "https://api.met.no/weatherapi/locationforecast/2.0/complete?lat="
         + encodeURIComponent(service.latitude)

--- a/contents/ui/providers/openMeteo.js
+++ b/contents/ui/providers/openMeteo.js
@@ -99,6 +99,7 @@ function fetchCurrent(service, chain, idx) {
             uvIndex:             (c.uv_index !== undefined) ? c.uv_index : NaN,
             snowDepthCm:         (c.snow_depth !== undefined && c.snow_depth !== null) ? c.snow_depth * 100 : NaN,
             locationUtcOffsetMins: (d.utc_offset_seconds !== undefined) ? Math.round(d.utc_offset_seconds / 60) : 0,
+            locationTimezoneAbbrev: (d.timezone_abbreviation !== undefined && d.timezone_abbreviation !== null) ? ("" + d.timezone_abbreviation) : "",
             sunriseTimeText:     (d.daily && d.daily.sunrise && d.daily.sunrise.length > 0) ? Qt.formatTime(new Date(d.daily.sunrise[0]), "HH:mm") : "--",
             sunsetTimeText:      (d.daily && d.daily.sunset  && d.daily.sunset.length  > 0) ? Qt.formatTime(new Date(d.daily.sunset[0]),  "HH:mm") : "--",
             dailyData:           nd

--- a/contents/ui/providers/openMeteo.js
+++ b/contents/ui/providers/openMeteo.js
@@ -26,7 +26,7 @@
 
 function fetchCurrent(service, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var tz = service.timezone;
     var url = "https://api.open-meteo.com/v1/forecast"
         + "?latitude=" + service.latitude
@@ -60,9 +60,13 @@ function fetchCurrent(service, chain, idx) {
         var nd = [];
         if (d.daily && d.daily.time) {
             var maxD = Math.min(service.forecastDays, d.daily.time.length);
-            for (var i = 0; i < maxD; ++i)
+            for (var i = 0; i < maxD; ++i) {
+                var parts = (d.daily.time[i] || "").split("-");
+                var dayDate = (parts.length === 3)
+                    ? new Date(parseInt(parts[0], 10), parseInt(parts[1], 10) - 1, parseInt(parts[2], 10), 12, 0, 0, 0)
+                    : new Date();
                 nd.push({
-                    day: Qt.formatDate(new Date(d.daily.time[i]), "ddd"),
+                    day: Qt.formatDate(dayDate, "ddd"),
                     dateStr: d.daily.time[i],
                     maxC: d.daily.temperature_2m_max[i],
                     minC: d.daily.temperature_2m_min[i],
@@ -74,8 +78,11 @@ function fetchCurrent(service, chain, idx) {
                     windDir: d.daily.wind_direction_10m_dominant ? d.daily.wind_direction_10m_dominant[i] : NaN,
                     uvMax: d.daily.uv_index_max ? d.daily.uv_index_max[i] : NaN,
                     pressureHpa: d.daily.pressure_msl_mean ? d.daily.pressure_msl_mean[i] : NaN,
-                    visibilityKm: d.daily.visibility_mean ? d.daily.visibility_mean[i] / 1000.0 : NaN
+                    visibilityKm: d.daily.visibility_mean ? d.daily.visibility_mean[i] / 1000.0 : NaN,
+                    sunriseTimeText: (d.daily.sunrise && d.daily.sunrise[i]) ? Qt.formatTime(new Date(d.daily.sunrise[i]), "HH:mm") : "--",
+                    sunsetTimeText: (d.daily.sunset && d.daily.sunset[i]) ? Qt.formatTime(new Date(d.daily.sunset[i]), "HH:mm") : "--"
                 });
+            }
         }
         r.weatherDataStaged = {
             temperatureC:        c.temperature_2m,
@@ -116,7 +123,7 @@ function _aqiLabel(aqi) {
 
 function _fetchAirQuality(service) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var tz = service.timezone;
     var url = "https://air-quality-api.open-meteo.com/v1/air-quality"
         + "?latitude=" + service.latitude
@@ -138,15 +145,16 @@ function _fetchAirQuality(service) {
         var d = JSON.parse(req.responseText);
         var c = d.current || {};
         var aqi = c.european_aqi;
+        var hasAqi = aqi !== undefined && aqi !== null && !isNaN(aqi);
         r.aqiDataStaged = {
-            index: (aqi !== undefined) ? aqi : NaN,
-            label: (aqi !== undefined) ? _aqiLabel(aqi) : "",
-            pm10:  (c.pm10            !== undefined) ? c.pm10            : NaN,
-            pm2_5: (c.pm2_5           !== undefined) ? c.pm2_5           : NaN,
-            no2:   (c.nitrogen_dioxide !== undefined) ? c.nitrogen_dioxide : NaN,
-            so2:   (c.sulphur_dioxide  !== undefined) ? c.sulphur_dioxide  : NaN,
-            o3:    (c.ozone            !== undefined) ? c.ozone            : NaN,
-            co:    (c.carbon_monoxide  !== undefined) ? c.carbon_monoxide / 1000.0 : NaN
+            index: hasAqi ? aqi : NaN,
+            label: hasAqi ? _aqiLabel(aqi) : "",
+            pm10:  (c.pm10             !== undefined && c.pm10             !== null && !isNaN(c.pm10))             ? c.pm10 : NaN,
+            pm2_5: (c.pm2_5            !== undefined && c.pm2_5            !== null && !isNaN(c.pm2_5))            ? c.pm2_5 : NaN,
+            no2:   (c.nitrogen_dioxide !== undefined && c.nitrogen_dioxide !== null && !isNaN(c.nitrogen_dioxide)) ? c.nitrogen_dioxide : NaN,
+            so2:   (c.sulphur_dioxide  !== undefined && c.sulphur_dioxide  !== null && !isNaN(c.sulphur_dioxide))  ? c.sulphur_dioxide : NaN,
+            o3:    (c.ozone            !== undefined && c.ozone            !== null && !isNaN(c.ozone))            ? c.ozone : NaN,
+            co:    (c.carbon_monoxide  !== undefined && c.carbon_monoxide  !== null && !isNaN(c.carbon_monoxide))  ? c.carbon_monoxide / 1000.0 : NaN
         };
         var pollenKeys = [
             { key: "alder",   field: "alder_pollen"   },
@@ -159,7 +167,8 @@ function _fetchAirQuality(service) {
         var pd = [];
         pollenKeys.forEach(function (p) {
             var v = c[p.field];
-            pd.push({ key: p.key, value: (v !== undefined && v !== null) ? v : NaN });
+            if (v !== undefined && v !== null && !isNaN(v))
+                pd.push({ key: p.key, value: v });
         });
         r.pollenDataStaged = pd;
     };
@@ -168,7 +177,7 @@ function _fetchAirQuality(service) {
 
 function fetchHourly(service, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var tz = service.timezone;
     var url = "https://api.open-meteo.com/v1/forecast?latitude="
         + service.latitude

--- a/contents/ui/providers/openWeather.js
+++ b/contents/ui/providers/openWeather.js
@@ -37,7 +37,7 @@ function _calcDewPoint(T, rh) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._owKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -162,10 +162,10 @@ function _owAqiLabel(aqi) {
 
 function _fetchAirQuality(service, W) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._owKey();
     if (!key) {
-        r.aqiData = null;
+        r.aqiDataStaged = null;
         return;
     }
     var url = "https://api.openweathermap.org/data/2.5/air_pollution?lat="
@@ -178,8 +178,8 @@ function _fetchAirQuality(service, W) {
             return;
         if (service._refreshGen !== gen) return;
         if (req.status !== 200) {
-            r.aqiData = null;
-            r.pollenData = [];
+            r.aqiDataStaged = null;
+            r.pollenDataStaged = [];
             return;
         }
         var d = JSON.parse(req.responseText);
@@ -187,16 +187,16 @@ function _fetchAirQuality(service, W) {
             var aqi = d.list[0].main.aqi;
             r.aqiDataStaged = { index: aqi, label: _owAqiLabel(aqi) };
         } else {
-            r.aqiData = null;
+            r.aqiDataStaged = null;
         }
-        r.pollenData = []; // not available in OpenWeather free tier
+        r.pollenDataStaged = []; // not available in OpenWeather free tier
     };
     req.send();
 }
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._owKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/pirateWeather.js
+++ b/contents/ui/providers/pirateWeather.js
@@ -97,7 +97,7 @@ function _iconIsDay(icon) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._pwKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -171,8 +171,8 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  day0 && day0.sunsetTime  ? Qt.formatTime(new Date(day0.sunsetTime  * 1000), "HH:mm") : "--",
             dailyData:       nd
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        r.aqiDataStaged = null;
+        r.pollenDataStaged = [];
         r.loading = false;
         r.updateText = service._formatUpdateText("pirateWeather");
 
@@ -242,7 +242,7 @@ function _parseAlerts(r, alerts) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._pwKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/qWeather.js
+++ b/contents/ui/providers/qWeather.js
@@ -222,6 +222,8 @@ function _fetchDailyAttempt(service, W, key, loc, gen, base, spans, spanIdx) {
                         code: _qwCodeToWmo(day.iconDay),
                         precipMm: (day.precip !== undefined && day.precip !== null) ? parseFloat(day.precip) : NaN,
                         snowCm: 0, // not separated in QWeather daily
+                        pressureHpa: (day.pressure !== undefined && day.pressure !== null) ? parseFloat(day.pressure) : NaN,
+                        visibilityKm: (day.vis !== undefined && day.vis !== null) ? parseFloat(day.vis) : NaN,
                         uvMax: (day.uvIndex !== undefined) ? parseFloat(day.uvIndex) : NaN,
                         precipProb: (day.pop !== undefined) ? parseFloat(day.pop) : NaN,
                         windKmh: (day.windSpeed !== undefined) ? parseFloat(day.windSpeed) : NaN,

--- a/contents/ui/providers/qWeather.js
+++ b/contents/ui/providers/qWeather.js
@@ -133,7 +133,7 @@ function _hourlySpanHours(dateStr) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._qwKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -196,7 +196,7 @@ function _fetchDaily(service, W, key, loc, gen, base) {
 }
 
 function _fetchDailyAttempt(service, W, key, loc, gen, base, spans, spanIdx) {
-    var r = service.weatherRoot;
+    var r = service;
     var span = spans[spanIdx];
     var url = base + "/v7/weather/" + span + "d?location=" + encodeURIComponent(loc)
         + "&unit=m";
@@ -248,7 +248,7 @@ function _fetchDailyAttempt(service, W, key, loc, gen, base, spans, spanIdx) {
             return;
         }
         service._qw_cur.dailyData = nd;
-        var r = service.weatherRoot;
+        var r = service;
         r.weatherDataStaged = service._qw_cur;
         service._qw_cur = null;
         r.loading = false;
@@ -272,7 +272,7 @@ function _qwAqiLabel(category) {
 }
 
 function _fetchAirQuality(service, W, key, loc, gen, base) {
-    var r = service.weatherRoot;
+    var r = service;
     var url = base + "/airquality/v1/current?location=" + encodeURIComponent(loc);
 
     var req = new XMLHttpRequest();
@@ -282,14 +282,14 @@ function _fetchAirQuality(service, W, key, loc, gen, base) {
         if (req.readyState !== XMLHttpRequest.DONE) return;
         if (service._refreshGen !== gen) return;
         if (req.status !== 200) {
-            r.aqiData = null;
-            r.pollenData = [];
+            r.aqiDataStaged = null;
+            r.pollenDataStaged = [];
             return;
         }
         var d;
         try { d = JSON.parse(req.responseText); } catch (e) {
-            r.aqiData = null;
-            r.pollenData = [];
+            r.aqiDataStaged = null;
+            r.pollenDataStaged = [];
             return;
         }
         if (d.code === "200" && d.indexes && d.indexes.length > 0) {
@@ -297,16 +297,16 @@ function _fetchAirQuality(service, W, key, loc, gen, base) {
             var aqi = parseFloat(idx.aqiDisplay) || NaN;
             r.aqiDataStaged = { index: aqi, label: _qwAqiLabel(parseInt(idx.category, 10)) };
         } else {
-            r.aqiData = null;
+            r.aqiDataStaged = null;
         }
-        r.pollenData = [];
+        r.pollenDataStaged = [];
     };
     req.send();
 }
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._qwKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/spaceWeather_provider.js
+++ b/contents/ui/providers/spaceWeather_provider.js
@@ -87,7 +87,7 @@ function _auroraVisibilityPercent(kp, latitude) {
  */
 function fetchSpaceWeather(service) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
 
     // Collector — wait for all 5 fetches to complete before assembling
     var state = {

--- a/contents/ui/providers/stormGlass.js
+++ b/contents/ui/providers/stormGlass.js
@@ -66,7 +66,7 @@ function _val(obj) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._sgKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -196,8 +196,8 @@ function fetchCurrent(service, W, chain, idx) {
         }
         _cur.dailyData = nd;
         r.weatherDataStaged = _cur;
-        r.aqiData = null;
-        r.pollenData = [];
+        r.aqiDataStaged = null;
+        r.pollenDataStaged = [];
         r.loading = false;
         r.updateText = service._formatUpdateText("stormGlass");
 
@@ -215,7 +215,7 @@ function fetchCurrent(service, W, chain, idx) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._sgKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/tomorrowIo.js
+++ b/contents/ui/providers/tomorrowIo.js
@@ -58,7 +58,7 @@ function _codeToWmo(code) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._tioKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -113,8 +113,8 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  "--",
             dailyData:       []
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        r.aqiDataStaged = null;
+        r.pollenDataStaged = [];
         // Step 2: Fetch daily forecast for dailyData + sun times, then write r.weatherData
         _fetchForecast(service, W, gen);
     };
@@ -126,7 +126,7 @@ function fetchCurrent(service, W, chain, idx) {
  * Sets dailyData, sunriseTimeText, sunsetTimeText, and isDay.
  */
 function _fetchForecast(service, W, gen) {
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._tioKey();
 
     var url = "https://api.tomorrow.io/v4/weather/forecast"
@@ -208,7 +208,7 @@ function _fetchForecast(service, W, gen) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._tioKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/visualCrossing.js
+++ b/contents/ui/providers/visualCrossing.js
@@ -79,7 +79,7 @@ function _iconIsDay(icon) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._vcKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -153,8 +153,8 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  c.sunset  ? c.sunset.substring(0, 5)  : "--",
             dailyData:       nd
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        r.aqiDataStaged = null;
+        r.pollenDataStaged = [];
         r.loading = false;
         r.updateText = service._formatUpdateText("visualCrossing");
 
@@ -213,7 +213,7 @@ function _parseAlerts(r, alerts) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._vcKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/weatherApi.js
+++ b/contents/ui/providers/weatherApi.js
@@ -69,7 +69,7 @@ function _apiTimeTo24h(s) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._waKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -102,9 +102,9 @@ function fetchCurrent(service, W, chain, idx) {
         if (aq) {
             r.aqiDataStaged = { index: (epa !== undefined) ? epa : NaN, label: _waAqiLabel(epa) };
         } else {
-            r.aqiData = null;
+            r.aqiDataStaged = null;
         }
-        r.pollenData = [];
+        r.pollenDataStaged = [];
         var astro = (d.forecast && d.forecast.forecastday && d.forecast.forecastday.length > 0)
             ? d.forecast.forecastday[0].astro : null;
         var nd = [];
@@ -210,7 +210,7 @@ function _parseAlerts(r, alerts) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._waKey();
     if (!key) {
         r.hourlyData = [];

--- a/contents/ui/providers/weatherbit.js
+++ b/contents/ui/providers/weatherbit.js
@@ -62,7 +62,7 @@ function _codeToWmo(code) {
 
 function fetchCurrent(service, W, chain, idx) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._wbKey();
     if (!key) {
         service._tryProvider(chain, idx + 1);
@@ -118,8 +118,8 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  c.sunset  || "--",
             dailyData:       []
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        r.aqiDataStaged = null;
+        r.pollenDataStaged = [];
         _fetchDailyForecast(service, W, gen);
     };
     req.send();
@@ -130,7 +130,7 @@ function fetchCurrent(service, W, chain, idx) {
  * Sets dailyData, then marks loading complete.
  */
 function _fetchDailyForecast(service, W, gen) {
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._wbKey();
 
     var url = "https://api.weatherbit.io/v2.0/forecast/daily"
@@ -190,7 +190,7 @@ function _fetchDailyForecast(service, W, gen) {
 
 function fetchHourly(service, W, dateStr) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
+    var r = service;
     var key = service._wbKey();
     if (!key) {
         r.hourlyData = [];


### PR DESCRIPTION
## Summary
- show a compact location-local time hint in the header when the selected location uses a different timezone than the host
- prefer common timezone abbreviations such as `CEST` when they are available, with an offset fallback when they are not
- keep the hint hidden when the centered header date/time is already enabled

## Notes
- This PR is intentionally stacked on #123.
- Until #123 is merged, this comparison against `feature/1.7.0` will also include the base rendering changes from that branch.
- After #123 lands, the remaining diff here is just the header time-hint feature.

## Testing
- `qmllint contents/ui/main.qml contents/ui/FullView.qml contents/ui/WeatherService.qml contents/ui/providers/openMeteo.js`
- `git diff --check upstream/feature/1.7.0..HEAD`

<img width="1031" height="913" alt="image" src="https://github.com/user-attachments/assets/fcec3af3-1cc3-467f-a0f6-bac2f7cedc49" />
<img width="1031" height="913" alt="image" src="https://github.com/user-attachments/assets/e750484c-5ef2-423b-8b1d-ec5227f477ce" />
