### PR TITLE
Handle missing Open-Meteo visibility values

### DIFF
--- a/contents/ui/providers/openMeteo.js
+++ b/contents/ui/providers/openMeteo.js
@@ -24,6 +24,10 @@
 
 .import "../js/weather.js" as W
 
+function _metersToKmOrNaN(value) {
+    return (value !== undefined && value !== null && !isNaN(value)) ? (value / 1000.0) : NaN;
+}
+
 function fetchCurrent(service, chain, idx) {
     var gen = service._refreshGen;
     var r = service.weatherRoot;
@@ -74,7 +78,7 @@ function fetchCurrent(service, chain, idx) {
                     windDir: d.daily.wind_direction_10m_dominant ? d.daily.wind_direction_10m_dominant[i] : NaN,
                     uvMax: d.daily.uv_index_max ? d.daily.uv_index_max[i] : NaN,
                     pressureHpa: d.daily.pressure_msl_mean ? d.daily.pressure_msl_mean[i] : NaN,
-                    visibilityKm: d.daily.visibility_mean ? d.daily.visibility_mean[i] / 1000.0 : NaN
+                    visibilityKm: d.daily.visibility_mean ? _metersToKmOrNaN(d.daily.visibility_mean[i]) : NaN
                 });
         }
         r.weatherDataStaged = {
@@ -85,7 +89,7 @@ function fetchCurrent(service, chain, idx) {
             windDirection:       isNaN(c.wind_direction_10m) ? NaN : c.wind_direction_10m,
             pressureHpa:         c.pressure_msl,   // sea-level pressure (matches Foreca et al.)
             dewPointC:           c.dew_point_2m,
-            visibilityKm:        c.visibility / 1000.0,
+            visibilityKm:        _metersToKmOrNaN(c.visibility),
             weatherCode:         c.weather_code,
             isDay:               (c.is_day !== undefined) ? c.is_day : -1,
             precipMmh:           (c.precipitation !== undefined) ? c.precipitation : NaN,
@@ -201,7 +205,7 @@ function fetchHourly(service, dateStr) {
                     precipProb: d.hourly.precipitation_probability ? d.hourly.precipitation_probability[i] : NaN,
                     precipMm: d.hourly.precipitation ? d.hourly.precipitation[i] : NaN,
                     pressureHpa: d.hourly.pressure_msl ? d.hourly.pressure_msl[i] : NaN,
-                    visibilityKm: d.hourly.visibility ? d.hourly.visibility[i] / 1000.0 : NaN,
+                    visibilityKm: d.hourly.visibility ? _metersToKmOrNaN(d.hourly.visibility[i]) : NaN,
                     uvIndex: d.hourly.uv_index ? d.hourly.uv_index[i] : NaN
                 });
         r.hourlyData = arr;


### PR DESCRIPTION
## Summary
- keep missing Open-Meteo visibility values as unavailable instead of converting them to `0.0 km`
- apply the same null-safe conversion for current, daily, and hourly visibility fields

## Why
Some Open-Meteo models, including `meteofrance_seamless`, return `null` visibility values for Paris. The previous code divided those `null` values by 1000, which produced a misleading `0.0 km` in the UI instead of `--`.

<img width="1377" height="909" alt="Screenshot_20260707_184118" src="https://github.com/user-attachments/assets/af9ce64f-c618-4302-9846-0edefa50befa" />
<img width="1377" height="909" alt="Screenshot_20260707_184131" src="https://github.com/user-attachments/assets/46296766-33ad-4260-bca6-406fcbca3757" />
<img width="1377" height="909" alt="image" src="https://github.com/user-attachments/assets/633fa639-4757-4d29-917a-d6d05b88b0af" />
