### PR TITLE
Add map background selection to both radar maps (libreWXR and RainViewer)

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -171,6 +171,11 @@
     <entry name="radarProvider"         type="String"><default>librewxr</default></entry>
     <entry name="radarLayer"            type="String"><default>librewxr</default></entry>
     <entry name="radarZoom"             type="Int"><default>9</default><min>3</min><max>18</max></entry>
+    <!-- Base map tiles under both radar maps. "auto" lets each map decide:
+         LibreWXR follows its own light/dark theme, RainViewer uses standard
+         OpenStreetMap. Any other value is an id from providers/mapProviders.js
+         and applies to both maps. -->
+    <entry name="mapBackground"         type="String"><default>auto</default></entry>
     <entry name="librewxrLayer"         type="String"><default>radar</default></entry>
     <entry name="librewxrColorScheme"   type="Int"><default>2</default><min>0</min><max>12</max></entry>
     <entry name="librewxrArrows"        type="Bool"><default>false</default></entry>

--- a/contents/ui/components/MapBackgroundChoices.qml
+++ b/contents/ui/components/MapBackgroundChoices.qml
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026  Petar Nedyalkov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * MapBackgroundChoices.qml — Translated labels for the map background picker
+ *
+ * The tile definitions live in providers/mapProviders.js; the labels live here
+ * because that is what the gettext extraction and the two radar views share.
+ * Both RadarWebEngineView and RadarWebEngineViewLibreWXR instantiate this and
+ * hand the resulting list to their Leaflet page.
+ */
+import QtQuick
+import "../providers/mapProviders.js" as MapProvidersJS
+
+QtObject {
+    id: choices
+
+    /**
+     * "dark" or "light": used to resolve the "auto" entry. Maps without a
+     * theme of their own leave this empty and get the standard OSM tiles.
+     */
+    property string themeHint: ""
+
+    /** Extra attribution appended to every entry, e.g. the map data provider. */
+    property string attributionSuffix: ""
+
+    readonly property var labels: ({
+        "auto": i18n("Automatic"),
+        "osm-standard": i18n("OpenStreetMap (standard)"),
+        "osm-humanitarian": i18n("Humanitarian (HOT)"),
+        "cyclosm": i18n("CyclOSM (cycling)"),
+        "opentopomap": i18n("OpenTopoMap (topographic)"),
+        "carto-positron": i18n("Carto Positron (light)"),
+        "carto-darkmatter": i18n("Carto Dark Matter (dark)")
+    })
+
+    /** Choices plus their resolved tile data, ready to inject into a page. */
+    readonly property var list: {
+        var out = [];
+        var order = MapProvidersJS.MAP_BACKGROUND_ORDER;
+        for (var i = 0; i < order.length; ++i) {
+            var id = order[i];
+            var p = MapProvidersJS.resolveMapBackground(id, choices.themeHint);
+            out.push({
+                id: id,
+                label: choices.labels[id] || id,
+                url: p.tileUrlTemplate,
+                attribution: p.attribution + choices.attributionSuffix,
+                maxZoom: p.maxZoom
+            });
+        }
+        return out;
+    }
+
+    function toJson() {
+        return JSON.stringify(choices.list);
+    }
+}

--- a/contents/ui/components/RadarWebEngineView.qml
+++ b/contents/ui/components/RadarWebEngineView.qml
@@ -20,6 +20,7 @@ import QtQuick.Controls
 import QtWebEngine
 import org.kde.kirigami as Kirigami
 import org.kde.plasma.plasmoid
+import "../providers/mapProviders.js" as MapProvidersJS
 
 Item {
     id: radarRoot
@@ -44,6 +45,9 @@ Item {
         return "rainviewer";
     }
     readonly property int    initialZoom: Plasmoid.configuration.radarZoom || 9
+    readonly property string mapBackground: Plasmoid.configuration.mapBackground || "auto"
+    /** Set while the in-map layer button is what changed the background. */
+    property bool _backgroundFromMap: false
 
     // The RainViewer weather-maps.json fetch used to be done with an XHR
     // *inside* the WebEngineView page. Pages created via loadHtml() can end
@@ -129,10 +133,21 @@ Item {
         { id: "pressure_new",      label: i18n("Pressure"),    glyph: "\uF079", freeKey: false }
     ]
 
+    // ── Base map choices offered by the in-map layer button ──────────────
+    // RainViewer has no light/dark theme of its own, so themeHint stays empty
+    // and "auto" resolves to the standard OSM tiles this map always used.
+    readonly property MapBackgroundChoices backgroundChoices: MapBackgroundChoices {}
+
     // ── Build the Leaflet HTML page ──────────────────────────────────────
-    function _buildHtml(lat, lon, owmKey, layer, initZoom) {
+    function _buildHtml(lat, lon, owmKey, layer, initZoom, mapBackground) {
         var owmKeyJs   = JSON.stringify(owmKey || "");
         var layerJs    = JSON.stringify(layer  || "rainviewer");
+        var baseMap    = MapProvidersJS.resolveMapBackground(mapBackground);
+        var baseUrlJs  = JSON.stringify(baseMap.tileUrlTemplate);
+        var baseAttrJs = JSON.stringify(baseMap.attribution);
+        var bgListJs   = radarRoot.backgroundChoices.toJson();
+        var bgCurrJs   = JSON.stringify(mapBackground || "auto");
+        var titleBg    = JSON.stringify(i18n("Map background"));
         var fontFamily = JSON.stringify(Kirigami.Theme.defaultFont.family || "sans-serif");
         var titlePrev  = JSON.stringify(i18n("Recent"));
         var titlePlay  = JSON.stringify(i18n("Play"));
@@ -153,6 +168,7 @@ Item {
         var svgPause = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill="white" d="M4 3h3v10H4zm5 0h3v10H9z"/><\/svg>';
         var svgNext  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill="white" d="M10.5 3H12v10h-1.5zM4.5 3l6 5-6 5z"/><\/svg>';
         var svgLoc   = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><circle cx="8" cy="8" r="3" fill="white"/><path fill="white" d="M8 1v2M8 13v2M1 8h2M13 8h2" stroke="white" stroke-width="1.5"/><circle cx="8" cy="8" r="6" fill="none" stroke="white" stroke-width="1.2"/><\/svg>';
+        var svgLayers = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill="white" d="M8 1.5L1.5 5 8 8.5 14.5 5 8 1.5z"/><path fill="none" stroke="white" stroke-width="1.3" d="M1.8 8.2L8 11.5l6.2-3.3M1.8 11.2L8 14.5l6.2-3.3"/><\/svg>';
         return '<!DOCTYPE html>\
 <html>\
 <head>\
@@ -185,6 +201,28 @@ Item {
   .base-dimmed img { filter: saturate(0.8) brightness(0.85); }\
   #timeLabel { font-size:10px; font-weight:bold; color:#fff; white-space:nowrap; \
     font-family:' + fontFamily + '; background:rgba(0,0,0,0.55); border-radius:6px; padding:2px 6px; }\
+  /* Sits inside #controls, under the player row, so the layers button is in\
+     the same corner as the one on the LibreWXR map. */\
+  #bgControl {\
+    display:flex; flex-direction:column; align-items:flex-end; gap:4px;\
+    font-family:' + fontFamily + ';\
+  }\
+  #btnBg {\
+    background:rgba(0,0,0,0.55); border:none; border-radius:6px;\
+    width:28px; height:28px; padding:0; cursor:pointer;\
+    display:flex; align-items:center; justify-content:center;\
+  }\
+  #btnBg:hover { background:rgba(0,0,0,0.75); }\
+  #btnBg img { width:16px; height:16px; display:block; }\
+  #bgMenu {\
+    display:none; background:rgba(0,0,0,0.75); border-radius:6px; padding:4px;\
+  }\
+  #bgMenu div {\
+    color:#fff; font-size:11px; padding:4px 8px; border-radius:4px;\
+    cursor:pointer; white-space:nowrap;\
+  }\
+  #bgMenu div:hover { background:rgba(255,255,255,0.2); }\
+  #bgMenu div.active { font-weight:bold; }\
 <\/style>\
 <\/head>\
 <body>\
@@ -198,6 +236,10 @@ Item {
     <button id="btnLoc" title=' + titleLoc   + '><img src="data:image/svg+xml,' + encodeURIComponent(svgLoc) + '"/><\/button>\
   <\/div>\
   <span id="timeLabel">Loading...<\/span>\
+  <div id="bgControl">\
+    <button id="btnBg" title=' + titleBg + '><img src="data:image/svg+xml,' + encodeURIComponent(svgLayers) + '"/><\/button>\
+    <div id="bgMenu"><\/div>\
+  <\/div>\
 <\/div>\
 <script>\
 var LAT = ' + lat + ';\
@@ -208,6 +250,17 @@ var ACTIVE_LAYER = ' + layerJs + ';\
 var SYS_LOCALE = ' + localeJs + ';\
 var LOC_INFO = ' + locInfoJs + ';\
 var HOUR12 = ' + hour12Js + ';\
+var BASE_TILE_URL = ' + baseUrlJs + ';\
+var BASE_ATTRIBUTION = ' + baseAttrJs + ';\
+var BASE_MAX_ZOOM = ' + baseMap.maxZoom + ';\
+var BG_LIST = ' + bgListJs + ';\
+var BG_CURRENT = ' + bgCurrJs + ';\
+/* Backgrounds stop at different zoom levels (OpenTopoMap at 17, OSM at 19),\
+   and radarZoom goes up to 18. Past its own maxZoom a Leaflet layer renders\
+   nothing at all, which would leave the base map blank under the radar, so\
+   cap every background at the same MAP_MAX_ZOOM and let Leaflet upscale the\
+   deepest tiles it does have through maxNativeZoom. */\
+var MAP_MAX_ZOOM = 19;\
 var TILE_SIZE = 512;\
 var RADAR_OPACITY = 0.6;\
 var OWM_OPACITY  = 1.00;\
@@ -220,10 +273,12 @@ var map = L.map("map", { zoomControl: true, attributionControl: true })\
 map.on("zoomend", function() { document.title = "zoom:" + map.getZoom(); });\
 \
 var _baseClass = (ACTIVE_LAYER !== "rainviewer") ? "base-dimmed" : "";\
-L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {\
-    attribution: "\u00a9 <a href=\'https://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors",\
-    maxZoom: 19,\
-    className: _baseClass\
+var baseLayer = L.tileLayer(BASE_TILE_URL, {\
+    attribution: BASE_ATTRIBUTION,\
+    maxNativeZoom: BASE_MAX_ZOOM,\
+    maxZoom: MAP_MAX_ZOOM,\
+    className: _baseClass,\
+    zIndex: 1\
 }).addTo(map);\
 \
 L.marker([LAT, LON]).addTo(map);\
@@ -448,6 +503,72 @@ document.getElementById("btnLoc").onclick   = function() { map.setView([LAT, LON
 \
 map.on("movestart", clearCache);\
 \
+function bgEntry(id) {\
+    for (var i = 0; i < BG_LIST.length; i++) if (BG_LIST[i].id === id) return BG_LIST[i];\
+    return BG_LIST[0];\
+}\
+\
+/* Keep the base map dimmed while an OWM overlay is on top, so precipitation\
+   stays readable. Applied to the live container, since the class has to follow\
+   layer switches and not just the initial page load.\
+   Block comment on purpose: this script is emitted as a single line. */\
+function updateBaseDim() {\
+    if (!baseLayer) return;\
+    var c = baseLayer.getContainer();\
+    if (!c) return;\
+    if (ACTIVE_LAYER !== "rainviewer") c.classList.add("base-dimmed");\
+    else c.classList.remove("base-dimmed");\
+}\
+\
+function applyBackground(id) {\
+    var e = bgEntry(id);\
+    BG_CURRENT = e.id;\
+    var next = L.tileLayer(e.url, {\
+        attribution: e.attribution,\
+        maxNativeZoom: e.maxZoom,\
+        maxZoom: MAP_MAX_ZOOM,\
+        zIndex: 1\
+    }).addTo(map);\
+    if (baseLayer) map.removeLayer(baseLayer);\
+    baseLayer = next;\
+    updateBaseDim();\
+    renderBgMenu();\
+}\
+\
+function renderBgMenu() {\
+    var menu = document.getElementById("bgMenu");\
+    menu.innerHTML = "";\
+    for (var i = 0; i < BG_LIST.length; i++) {\
+        (function(entry) {\
+            var row = document.createElement("div");\
+            row.textContent = entry.label;\
+            if (entry.id === BG_CURRENT) row.className = "active";\
+            row.onclick = function(ev) {\
+                ev.stopPropagation();\
+                menu.style.display = "none";\
+                if (entry.id === BG_CURRENT) return;\
+                applyBackground(entry.id);\
+                document.title = "bg:" + entry.id;\
+            };\
+            menu.appendChild(row);\
+        })(BG_LIST[i]);\
+    }\
+}\
+\
+document.getElementById("btnBg").onclick = function(ev) {\
+    ev.stopPropagation();\
+    var menu = document.getElementById("bgMenu");\
+    menu.style.display = (menu.style.display === "block") ? "none" : "block";\
+};\
+document.addEventListener("click", function() {\
+    document.getElementById("bgMenu").style.display = "none";\
+});\
+renderBgMenu();\
+\
+window.setBackground = function(id) {\
+    if (id !== BG_CURRENT) applyBackground(id);\
+};\
+\
 window.setLayer = function(layer, owmKey) {\
     ACTIVE_LAYER = layer;\
     OWM_KEY = owmKey || "";\
@@ -553,7 +674,7 @@ loadApi();\
             onContextMenuRequested: function(request) { request.accepted = true; }
 
             Component.onCompleted: {
-                var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom);
+                var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom, radarRoot.mapBackground);
                 console.log("[Advanced Weather Widget Radar/WebEngine] WebEngineView completed; calling loadHtml, htmlLength=", html.length);
                 radarRoot.webViewPageReady = false;
                 webView.loadHtml(html, "https://rainviewer.com/");
@@ -588,6 +709,14 @@ loadApi();\
                     if (!isNaN(z) && z !== Plasmoid.configuration.radarZoom) {
                         Plasmoid.configuration.radarZoom = z;
                     }
+                } else if (title.indexOf("bg:") === 0) {
+                    // Picked from the in-map layer button: the page already swapped
+                    // its tiles, so persist the choice without reloading the page.
+                    var bg = title.substring(3);
+                    if (bg.length > 0 && bg !== Plasmoid.configuration.mapBackground) {
+                        radarRoot._backgroundFromMap = true;
+                        Plasmoid.configuration.mapBackground = bg;
+                    }
                 }
             }
 
@@ -595,18 +724,28 @@ loadApi();\
             Connections {
                 target: radarRoot
                 function onLatChanged() {
-                    var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom);
+                    var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom, radarRoot.mapBackground);
                     console.log("[Advanced Weather Widget Radar/WebEngine] latitude changed; reloading html, lat=", radarRoot.lat, "lon=", radarRoot.lon);
                     radarRoot.webViewPageReady = false;
                     radarRoot._fetchRainviewerApi();
                     webView.loadHtml(html, "https://rainviewer.com/");
                 }
                 function onLonChanged() {
-                    var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom);
+                    var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom, radarRoot.mapBackground);
                     console.log("[Advanced Weather Widget Radar/WebEngine] longitude changed; reloading html, lat=", radarRoot.lat, "lon=", radarRoot.lon);
                     radarRoot.webViewPageReady = false;
                     radarRoot._fetchRainviewerApi();
                     webView.loadHtml(html, "https://rainviewer.com/");
+                }
+                function onMapBackgroundChanged() {
+                    if (radarRoot._backgroundFromMap) {
+                        // The map itself made the change; swapping tiles again
+                        // would throw away the current pan and zoom.
+                        radarRoot._backgroundFromMap = false;
+                        return;
+                    }
+                    console.log("[Advanced Weather Widget Radar/WebEngine] map background changed; background=", radarRoot.mapBackground);
+                    webView.runJavaScript("window.setBackground(" + JSON.stringify(radarRoot.mapBackground) + ");");
                 }
             }
         }
@@ -706,7 +845,7 @@ loadApi();\
     }
 
     function reload() {
-        var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom);
+        var html = radarRoot._buildHtml(radarRoot.lat, radarRoot.lon, radarRoot.owmKey, radarRoot.activeLayer, radarRoot.initialZoom, radarRoot.mapBackground);
         console.log("[Advanced Weather Widget Radar/WebEngine] reload; htmlLength=", html.length,
                     "lat=", radarRoot.lat, "lon=", radarRoot.lon,
                     "layer=", radarRoot.activeLayer);

--- a/contents/ui/components/RadarWebEngineViewLibreWXR.qml
+++ b/contents/ui/components/RadarWebEngineViewLibreWXR.qml
@@ -19,6 +19,8 @@
  * - Radar color scheme and motion-arrows toggle, in-widget (not in settings)
  * - Base map follows the KDE Plasma light/dark theme automatically; arrow
  *   color follows the map theme
+ * - In-map picker to pin a different base map (shared with RadarWebEngineView
+ *   through providers/mapProviders.js), which then stops following the theme
  */
 import QtQuick
 import QtQuick.Layouts
@@ -57,6 +59,20 @@ Item {
         if (themeOverride === "light" || themeOverride === "dark")
             return themeOverride;
         return isDark ? "dark" : "light";
+    }
+
+    // ── Base map background ──────────────────────────────────────────────
+    // "auto" keeps the theme-driven pair this map has always used (OSM in
+    // light, Carto Dark Matter in dark); any other id pins one background
+    // regardless of the theme. The page re-resolves "auto" itself on theme
+    // switches, so themeHint only seeds the initial load.
+    readonly property string mapBackground: Plasmoid.configuration.mapBackground || "auto"
+    /** Set while the in-map picker is what changed the background. */
+    property bool _backgroundFromMap: false
+
+    readonly property MapBackgroundChoices backgroundChoices: MapBackgroundChoices {
+        themeHint: radarRoot.mapTheme
+        attributionSuffix: " | <a href=\"https://librewxr.net/\">LibreWXR</a>"
     }
 
     // A manual "Dark map" toggle only sticks until the Plasma theme itself
@@ -162,7 +178,7 @@ Item {
             "apiError": i18n("API error"),
             "connFailed": i18n("Connection failed")
         };
-        return Qt.resolvedUrl("librewxr-map.html") + "?lat=" + radarRoot.lat + "&lon=" + radarRoot.lon + "&zoom=" + radarRoot.initialZoom + "&layer=" + encodeURIComponent(radarRoot.activeLayer) + "&color=" + radarRoot.colorScheme + "&arrows=" + (radarRoot.arrowsOn ? "1" : "0") + "&theme=" + radarRoot.mapTheme + "&server=" + encodeURIComponent(radarRoot.serverUrl) + "&hour12=" + (radarRoot.is24h ? "0" : "1") + "&locale=" + encodeURIComponent(Qt.locale().name.replace("_", "-")) + "&strings=" + encodeURIComponent(JSON.stringify(strings));
+        return Qt.resolvedUrl("librewxr-map.html") + "?lat=" + radarRoot.lat + "&lon=" + radarRoot.lon + "&zoom=" + radarRoot.initialZoom + "&layer=" + encodeURIComponent(radarRoot.activeLayer) + "&color=" + radarRoot.colorScheme + "&arrows=" + (radarRoot.arrowsOn ? "1" : "0") + "&theme=" + radarRoot.mapTheme + "&server=" + encodeURIComponent(radarRoot.serverUrl) + "&hour12=" + (radarRoot.is24h ? "0" : "1") + "&locale=" + encodeURIComponent(Qt.locale().name.replace("_", "-")) + "&strings=" + encodeURIComponent(JSON.stringify(strings)) + "&bg=" + encodeURIComponent(radarRoot.mapBackground) + "&bglist=" + encodeURIComponent(radarRoot.backgroundChoices.toJson());
     }
 
     function _loadPage(reason) {
@@ -397,6 +413,14 @@ Item {
                     if (!isNaN(z) && z !== Plasmoid.configuration.radarZoom) {
                         Plasmoid.configuration.radarZoom = z;
                     }
+                } else if (title.indexOf("bg:") === 0) {
+                    // Picked from the in-map picker: the page already swapped
+                    // its tiles, so persist the choice without reloading.
+                    var bg = title.substring(3);
+                    if (bg.length > 0 && bg !== Plasmoid.configuration.mapBackground) {
+                        radarRoot._backgroundFromMap = true;
+                        Plasmoid.configuration.mapBackground = bg;
+                    }
                 }
             }
 
@@ -416,6 +440,16 @@ Item {
                 function onMapThemeChanged() {
                     console.log("[Advanced Weather Widget Radar/LibreWXR] Plasma theme changed; mapTheme=", radarRoot.mapTheme);
                     webView.runJavaScript("window.setTheme(" + JSON.stringify(radarRoot.mapTheme) + ");");
+                }
+                function onMapBackgroundChanged() {
+                    if (radarRoot._backgroundFromMap) {
+                        // The map itself made the change; swapping tiles again
+                        // would throw away the current pan and zoom.
+                        radarRoot._backgroundFromMap = false;
+                        return;
+                    }
+                    console.log("[Advanced Weather Widget Radar/LibreWXR] map background changed; background=", radarRoot.mapBackground);
+                    webView.runJavaScript("window.setBackground(" + JSON.stringify(radarRoot.mapBackground) + ");");
                 }
             }
         }

--- a/contents/ui/components/RadarWebEngineViewLibreWXR.qml
+++ b/contents/ui/components/RadarWebEngineViewLibreWXR.qml
@@ -373,8 +373,18 @@ Item {
 
             onLoadingChanged: function (loadRequest) {
                 console.log("[Advanced Weather Widget Radar/LibreWXR] loading changed:", "status=", loadRequest.status, "url=", loadRequest.url, "errorCode=", loadRequest.errorCode, "error=", loadRequest.errorString);
-                if (loadRequest.status === WebEngineView.LoadSucceededStatus)
+                if (loadRequest.status === WebEngineView.LoadSucceededStatus) {
                     viewportFixTimer.restart();
+                    // mapTheme can still flip while the page is loading: Kirigami
+                    // reports a different background color early in startup, and
+                    // the component is rebuilt every time the popup reopens. Those
+                    // setTheme calls land on a page that does not exist yet and are
+                    // lost, leaving the page on the theme frozen into its URL while
+                    // the Dark map switch already shows the new one. Re-assert it
+                    // here so the switch, the page and the "auto" background agree.
+                    // No-op when they already match.
+                    webView.runJavaScript("window.setTheme(" + JSON.stringify(radarRoot.mapTheme) + ");");
+                }
             }
 
             // After a (re)load, Leaflet may size itself against a stale

--- a/contents/ui/components/librewxr-map.html
+++ b/contents/ui/components/librewxr-map.html
@@ -136,6 +136,67 @@
             stroke-linejoin: round;
         }
 
+        /* === BASE MAP PICKER === */
+        .bg-picker {
+            position: absolute;
+            top: 52px;
+            right: 10px;
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 4px;
+        }
+        .bg-btn {
+            width: 34px;
+            height: 34px;
+            background: var(--btn-bg);
+            border: 1px solid var(--btn-border);
+            border-radius: 6px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+        }
+        .bg-btn:hover {
+            background: var(--btn-hover);
+        }
+        .bg-btn svg {
+            width: 18px;
+            height: 18px;
+            fill: none;
+            stroke: var(--text-secondary);
+            stroke-width: 2;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+        }
+        .bg-menu {
+            display: none;
+            background: var(--btn-bg);
+            border: 1px solid var(--btn-border);
+            border-radius: 6px;
+            padding: 4px;
+        }
+        .bg-menu.open {
+            display: block;
+        }
+        .bg-menu div {
+            color: var(--text);
+            font-size: 11px;
+            padding: 4px 8px;
+            border-radius: 4px;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+        .bg-menu div:hover {
+            background: var(--btn-hover);
+        }
+        .bg-menu div.active {
+            font-weight: bold;
+            color: var(--accent);
+        }
+
         /* === REPLAYER / SCRUBBER === */
         .replayer {
             background: var(--replayer-bg);
@@ -317,6 +378,16 @@
             <line x1="18" y1="12" x2="22" y2="12"/>
         </svg>
     </button>
+    <div class="bg-picker" id="bgPicker">
+        <button class="bg-btn" id="bgBtn">
+            <svg viewBox="0 0 24 24">
+                <polygon points="12,3 21,7.5 12,12 3,7.5"/>
+                <polyline points="3,12 12,16.5 21,12"/>
+                <polyline points="3,16.5 12,21 21,16.5"/>
+            </svg>
+        </button>
+        <div class="bg-menu" id="bgMenu"></div>
+    </div>
 </div>
 
 <!-- Replayer / Scrubber -->
@@ -359,6 +430,12 @@ var SYS_LOCALE = PARAMS.get('locale') || undefined;
 var STRINGS = {};
 try { STRINGS = JSON.parse(PARAMS.get('strings') || '{}'); } catch (e) {}
 function tr(key, fallback) { return STRINGS[key] || fallback; }
+// Base map choices, resolved and translated on the QML side. The "auto" entry
+// is already resolved against the current map theme, but it stays a distinct
+// id so that switching the theme keeps following it (see setBaseMap).
+var BG_LIST = [];
+try { BG_LIST = JSON.parse(PARAMS.get('bglist') || '[]'); } catch (e) {}
+var BG_CURRENT = PARAMS.get('bg') || 'auto';
 
 // === CONFIGURATION ===
 var TILE_SIZE = 512;
@@ -411,24 +488,57 @@ map.getPane('satellite-pane').style.zIndex = 350;
 map.createPane('radar-pane');
 map.getPane('radar-pane').style.zIndex = 450;
 
-var baseMaps = {
-    dark: L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+// Fallback tiles for the (unexpected) case where QML sent no choices at all;
+// these are the two base maps this page used before the picker existed.
+var FALLBACK_BG = {
+    dark: {
+        id: 'auto',
+        url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
         attribution: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a> | <a href="https://librewxr.net/">LibreWXR</a>'
-    }),
-    light: L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    },
+    light: {
+        id: 'auto',
+        url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         attribution: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors | <a href="https://librewxr.net/">LibreWXR</a>'
-    })
+    }
 };
+
+function bgEntry(id) {
+    for (var i = 0; i < BG_LIST.length; i++) {
+        if (BG_LIST[i].id === id) return BG_LIST[i];
+    }
+    return null;
+}
+
+/* The "auto" entry sent by QML was resolved against the theme that was active
+ * when the page loaded, so it is re-resolved here on every theme switch. */
+function resolveBg(id, theme) {
+    if (id === 'auto') {
+        var themed = bgEntry(theme === 'dark' ? 'carto-darkmatter' : 'osm-standard');
+        return themed || FALLBACK_BG[theme] || FALLBACK_BG.dark;
+    }
+    return bgEntry(id) || FALLBACK_BG[theme] || FALLBACK_BG.dark;
+}
+
 var currentBaseMap = null;
 
 function setBaseMap(theme) {
+    var e = resolveBg(BG_CURRENT, theme);
     if (currentBaseMap) map.removeLayer(currentBaseMap);
-    currentBaseMap = baseMaps[theme];
+    // Backgrounds stop at different zoom levels; past its own maxZoom a
+    // Leaflet layer renders nothing, so upscale the deepest tiles it has
+    // instead of leaving the base map blank under the radar.
+    currentBaseMap = L.tileLayer(e.url, {
+        attribution: e.attribution,
+        maxNativeZoom: e.maxZoom || 19,
+        maxZoom: 19
+    });
     currentBaseMap.addTo(map);
     currentBaseMap.bringToBack();
 }
 
 setBaseMap(activeTheme);
+renderBgMenu();
 
 L.marker([LAT, LON]).addTo(map);
 
@@ -459,18 +569,61 @@ window.setArrows = function(on) {
     showFrame(animationPosition);
 };
 
+window.setBackground = function(id) {
+    if (id === BG_CURRENT) return;
+    BG_CURRENT = id;
+    setBaseMap(activeTheme);
+    renderBgMenu();
+};
+
 window.setTheme = function(theme) {
     if (theme !== 'light' && theme !== 'dark') return;
     if (theme === activeTheme) return;
     activeTheme = theme;
     document.body.setAttribute('data-theme', activeTheme);
-    setBaseMap(activeTheme);
+    // Only "auto" follows the theme; an explicit background stays put.
+    if (BG_CURRENT === 'auto') setBaseMap(activeTheme);
     // Arrow color follows the map theme, so radar tiles must be re-fetched
     if (arrowsOn && activeLayer !== 'satellite') {
         clearAllLayers();
         showFrame(animationPosition);
     }
 };
+
+// === BASE MAP PICKER UI ===
+function renderBgMenu() {
+    var menu = document.getElementById('bgMenu');
+    if (!menu) return;
+    menu.innerHTML = '';
+    if (BG_LIST.length === 0) {
+        document.getElementById('bgPicker').style.display = 'none';
+        return;
+    }
+    for (var i = 0; i < BG_LIST.length; i++) {
+        (function(entry) {
+            var row = document.createElement('div');
+            row.textContent = entry.label;
+            if (entry.id === BG_CURRENT) row.className = 'active';
+            row.onclick = function(ev) {
+                ev.stopPropagation();
+                menu.classList.remove('open');
+                if (entry.id === BG_CURRENT) return;
+                window.setBackground(entry.id);
+                // Report the choice to QML so it is persisted
+                document.title = 'bg:' + entry.id;
+            };
+            menu.appendChild(row);
+        })(BG_LIST[i]);
+    }
+}
+
+document.getElementById('bgBtn').onclick = function(ev) {
+    ev.stopPropagation();
+    document.getElementById('bgMenu').classList.toggle('open');
+};
+document.addEventListener('click', function() {
+    document.getElementById('bgMenu').classList.remove('open');
+});
 
 // === UTILITIES ===
 function clampPosition(position) {

--- a/contents/ui/components/qmldir
+++ b/contents/ui/components/qmldir
@@ -2,5 +2,6 @@ WeatherIcon 1.0 WeatherIcon.qml
 TemperatureBadge 1.0 TemperatureBadge.qml
 CollapsibleCardHeader 1.0 CollapsibleCardHeader.qml
 ConfigLocationPositionSources 1.0 ConfigLocationPositionSources.qml
+MapBackgroundChoices 1.0 MapBackgroundChoices.qml
 RadarWebEngineView 1.0 RadarWebEngineView.qml
 RadarWebEngineViewLibreWXR 1.0 RadarWebEngineViewLibreWXR.qml

--- a/contents/ui/providers/mapProviders.js
+++ b/contents/ui/providers/mapProviders.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026  Petar Nedyalkov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * mapProviders.js — Shared base map (background tile) definitions
+ *
+ * Single source of truth for the tile layers offered by the "Map background"
+ * setting. Consumed by two different map engines:
+ *
+ *   - Leaflet (RadarWebEngineView.qml) uses tileUrlTemplate, which keeps the
+ *     {s} subdomain placeholder for round-robin tile fetching.
+ *   - QtLocation (ConfigMapSubPage.qml) uses singleHost, since its "osm"
+ *     plugin takes one fixed host and appends {z}/{x}/{y}.png itself.
+ *
+ * All providers are free and require no API key. Attribution strings are HTML
+ * because both consumers render rich text.
+ *
+ * Non-pragma JS — plain globals, imported with "as MapProvidersJS".
+ */
+
+var _OSM_LINK = "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors";
+
+var MAP_BACKGROUNDS = {
+    "osm-standard": {
+        tileUrlTemplate: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        singleHost: "https://tile.openstreetmap.org/",
+        maxZoom: 19,
+        attribution: _OSM_LINK
+    },
+    "osm-humanitarian": {
+        tileUrlTemplate: "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        singleHost: "https://a.tile.openstreetmap.fr/hot/",
+        maxZoom: 20,
+        attribution: _OSM_LINK + " | Tiles style by <a href='https://www.hotosm.org/'>HOT</a>"
+    },
+    "cyclosm": {
+        tileUrlTemplate: "https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png",
+        singleHost: "https://a.tile-cyclosm.openstreetmap.fr/cyclosm/",
+        maxZoom: 20,
+        attribution: _OSM_LINK + " | Tiles style by <a href='https://www.cyclosm.org/'>CyclOSM</a>"
+    },
+    "opentopomap": {
+        tileUrlTemplate: "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
+        singleHost: "https://a.tile.opentopomap.org/",
+        maxZoom: 17,
+        attribution: _OSM_LINK + ", SRTM | © <a href='https://opentopomap.org/'>OpenTopoMap</a> (CC-BY-SA)"
+    },
+    "carto-positron": {
+        tileUrlTemplate: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+        singleHost: "https://a.basemaps.cartocdn.com/light_all/",
+        maxZoom: 20,
+        attribution: _OSM_LINK + " © <a href='https://carto.com/attributions'>CARTO</a>"
+    },
+    "carto-darkmatter": {
+        tileUrlTemplate: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+        singleHost: "https://a.basemaps.cartocdn.com/dark_all/",
+        maxZoom: 20,
+        attribution: _OSM_LINK + " © <a href='https://carto.com/attributions'>CARTO</a>"
+    }
+};
+
+var DEFAULT_MAP_BACKGROUND = "osm-standard";
+
+/**
+ * "auto" is the shipped default: the widget picks the background instead of
+ * the user. Maps that have a light/dark theme of their own (LibreWXR) resolve
+ * it against that theme, which reproduces exactly what they did before this
+ * setting existed; maps that have no theme (RainViewer) get the standard OSM
+ * tiles they always used.
+ */
+var AUTO_MAP_BACKGROUND = "auto";
+
+/** Ids offered by the "Map background" picker, in display order. */
+var MAP_BACKGROUND_ORDER = ["auto", "osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "carto-positron", "carto-darkmatter"];
+
+/**
+ * Resolve a background id to its definition.
+ *
+ * @param id         one of MAP_BACKGROUND_ORDER; anything unknown falls back
+ *                   to the default background
+ * @param themeHint  "dark" or "light", only consulted for "auto"; omit it on
+ *                   maps that have no theme of their own
+ */
+function resolveMapBackground(id, themeHint) {
+    if (id === AUTO_MAP_BACKGROUND)
+        return MAP_BACKGROUNDS[themeHint === "dark" ? "carto-darkmatter" : DEFAULT_MAP_BACKGROUND];
+    return MAP_BACKGROUNDS[id] || MAP_BACKGROUNDS[DEFAULT_MAP_BACKGROUND];
+}


### PR DESCRIPTION
Why:

- First answer is why not ;)
- Allows users to add legibility on some maps where the weather layer is not too visible.
  A light or dark background can help to view some layers.

Add a layers button in the corner of the radar map that switches the base tiles between OpenStreetMap standard, Humanitarian, CyclOSM, OpenTopoMap, Carto Positron and Carto Dark Matter. All of them are free and need no API key. The choice is stored in mapBackground and defaults to the standard layer, so existing setups look unchanged.

Tile definitions live in providers/mapProviders.js, so the other map in the widget can reuse them later.

On the implementation side, picking a background swaps the Leaflet tile layer
in place instead of regenerating the page, so the current pan, zoom and running
radar animation are preserved.

Things you may want to weigh in on:

This changes how the map looks in one case, so I want to flag it rather than
slip it in. The `base-dimmed` rule that dims the base map under the
OpenWeatherMap overlays was only applied when the page first loaded. Since
overlays are switched through the layer pills, which do not reload the page, in
practice it almost never took effect. It now follows those switches. The effect
itself is untouched, still the existing saturate 0.8 and brightness 0.85, but
people will now see the background dim under Rain, Clouds, Temperature, Wind
and Pressure where it used to stay bright. It looked like the intended
behaviour, and it makes precipitation easier to read, but it is a visible
change on an existing feature so say the word if you would rather keep it as it
was.