### PR TITLE
Let the panel temperature follow the forecast curve colors

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -119,6 +119,10 @@
     <entry name="panelSimpleTempShadowIntensity" type="Double"><default>0.8</default></entry>
     <entry name="panelSimpleTempShadowColor" type="String"><default></default></entry>
     <entry name="simpleTempColor" type="String"><default></default></entry>
+    <!-- When true, the panel temperature takes its color from the same
+         cold-to-hot scale as the forecast curve (js/tempColors.js) instead of
+         the fixed simpleTempColor above. -->
+    <entry name="simpleTempColorDynamic" type="Bool"><default>false</default></entry>
     <!-- Compressed mode: badge position, spacing, background color -->
     <entry name="compressedBadgePosition"  type="String"><default>bottom-right</default></entry>
     <entry name="compressedBadgeSpacing"   type="Int"><default>0</default><min>-20</min><max>20</max></entry>

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -53,6 +53,7 @@ import org.kde.kirigami as Kirigami
 
 import "js/weather.js" as W
 import "js/iconResolver.js" as IconResolver
+import "js/tempColors.js" as TempColorsJS
 import "js/configUtils.js" as ConfigUtils
 import "components"
 
@@ -98,7 +99,12 @@ PlasmaCore.ToolTipArea {
         var c = Plasmoid.configuration.panelSimpleTempShadowColor;
         return (c && c.length > 0) ? c : Kirigami.Theme.backgroundColor;
     }
+    // Follows the same cold-to-hot scale as the forecast curve when enabled,
+    // so the panel reading and the curve below it speak the same language.
+    readonly property bool simpleTempColorDynamic: Plasmoid.configuration.simpleTempColorDynamic === true
     readonly property color simpleTempColor: {
+        if (compactRoot.simpleTempColorDynamic && weatherRoot && weatherRoot.temperatureC !== undefined && weatherRoot.temperatureC !== null)
+            return TempColorsJS.colorForTemperature(weatherRoot.temperatureC, TempColorsJS.isDarkBackground(Kirigami.Theme.backgroundColor));
         var c = Plasmoid.configuration.simpleTempColor;
         return (c && c.length > 0) ? c : Kirigami.Theme.textColor;
     }

--- a/contents/ui/ForecastView.qml
+++ b/contents/ui/ForecastView.qml
@@ -27,6 +27,7 @@ import org.kde.plasma.plasmoid
 import "js/weather.js" as W
 import "js/iconResolver.js" as IconResolver
 import "js/configUtils.js" as ConfigUtils
+import "js/tempColors.js" as TempColorsJS
 import "components"
 
 Item {
@@ -1030,36 +1031,9 @@ Item {
                                             onDarkThemeChanged: requestPaint()
 
                                             // Map a temperature in °C to a CSS color string
+                                            // (scale shared with the panel temperature, see js/tempColors.js)
                                             function tempColor(t) {
-                                                // Dark theme: bright/pastel stops readable on dark bg
-                                                // Light theme: deeper/saturated stops readable on light bg
-                                                var stops = darkTheme ? [
-                                                    { t: -10, r:  50, g: 100, b: 255 },
-                                                    { t:   0, r:   0, g: 180, b: 255 },
-                                                    { t:  10, r:  80, g: 220, b: 160 },
-                                                    { t:  20, r: 220, g: 220, b:  40 },
-                                                    { t:  30, r: 255, g: 130, b:   0 },
-                                                    { t:  40, r: 220, g:  30, b:  30 }
-                                                ] : [
-                                                    { t: -10, r:  20, g:  60, b: 200 },
-                                                    { t:   0, r:   0, g: 120, b: 210 },
-                                                    { t:  10, r:   0, g: 160, b:  80 },
-                                                    { t:  20, r: 170, g: 150, b:   0 },
-                                                    { t:  30, r: 210, g:  80, b:   0 },
-                                                    { t:  40, r: 180, g:  10, b:  10 }
-                                                ];
-                                                if (t <= stops[0].t) return "rgba(" + stops[0].r + "," + stops[0].g + "," + stops[0].b + ",1.0)";
-                                                if (t >= stops[stops.length-1].t) { var s=stops[stops.length-1]; return "rgba("+s.r+","+s.g+","+s.b+",1.0)"; }
-                                                for (var i = 1; i < stops.length; i++) {
-                                                    if (t <= stops[i].t) {
-                                                        var frac = (t - stops[i-1].t) / (stops[i].t - stops[i-1].t);
-                                                        var r = Math.round(stops[i-1].r + frac * (stops[i].r - stops[i-1].r));
-                                                        var g = Math.round(stops[i-1].g + frac * (stops[i].g - stops[i-1].g));
-                                                        var b = Math.round(stops[i-1].b + frac * (stops[i].b - stops[i-1].b));
-                                                        return "rgba(" + r + "," + g + "," + b + ",1.0)";
-                                                    }
-                                                }
-                                                return "rgba(0,0,0,0.8)";
+                                                return TempColorsJS.cssForTemperature(t, darkTheme);
                                             }
 
                                             onPaint: {

--- a/contents/ui/config/configAppearance.qml
+++ b/contents/ui/config/configAppearance.qml
@@ -1070,6 +1070,7 @@ KCM.AbstractKCM {
     property double cfg_panelSimpleTempShadowIntensity: 0.8
     property string cfg_panelSimpleTempShadowColor: ""   // empty = theme background
     property string cfg_simpleTempColor: ""              // empty = theme text color
+    property bool   cfg_simpleTempColorDynamic: false    // true = follow the forecast curve scale
     // Compressed badge options
     property string cfg_compressedBadgePosition: "bottom-right"
     property int cfg_compressedBadgeSpacing: 0

--- a/contents/ui/config/tabs/ConfigPanelTab.qml
+++ b/contents/ui/config/tabs/ConfigPanelTab.qml
@@ -525,6 +525,10 @@ Kirigami.FormLayout {
             ToolTip.text: i18n("Color the panel temperature with the same cold to hot scale as the forecast curve, instead of a fixed color.")
             ToolTip.delay: Kirigami.Units.toolTipDelay
         }
+        Label {
+            text: panelTab.configRoot.cfg_simpleTempColorDynamic ? i18n("Enabled") : i18n("Disabled")
+            opacity: 0.8
+        }
     }
 
     RowLayout {

--- a/contents/ui/config/tabs/ConfigPanelTab.qml
+++ b/contents/ui/config/tabs/ConfigPanelTab.qml
@@ -475,6 +475,7 @@ Kirigami.FormLayout {
             width: 24
             height: 24
             radius: 4
+            opacity: panelTab.configRoot.cfg_simpleTempColorDynamic ? 0.4 : 1.0
             border.color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.3)
             border.width: 1
             color: {
@@ -483,6 +484,7 @@ Kirigami.FormLayout {
             }
             MouseArea {
                 anchors.fill: parent
+                enabled: !panelTab.configRoot.cfg_simpleTempColorDynamic
                 cursorShape: Qt.PointingHandCursor
                 onClicked: simpleTempColorDialog.open()
             }
@@ -490,12 +492,14 @@ Kirigami.FormLayout {
         TextField {
             Layout.preferredWidth: 110
             readOnly: true
+            enabled: !panelTab.configRoot.cfg_simpleTempColorDynamic
             text: {
                 var c = panelTab.configRoot.cfg_simpleTempColor;
                 return (c && c.length > 0) ? c : i18n("Default");
             }
             MouseArea {
                 anchors.fill: parent
+                enabled: !panelTab.configRoot.cfg_simpleTempColorDynamic
                 cursorShape: Qt.PointingHandCursor
                 onClicked: simpleTempColorDialog.open()
             }
@@ -503,7 +507,23 @@ Kirigami.FormLayout {
         Button {
             text: i18n("Reset")
             visible: (panelTab.configRoot.cfg_simpleTempColor || "").length > 0
+            enabled: !panelTab.configRoot.cfg_simpleTempColorDynamic
             onClicked: panelTab.configRoot.cfg_simpleTempColor = ""
+        }
+    }
+
+    // ── Simple mode: temperature color follows the forecast curve ────────────
+    RowLayout {
+        visible: !panelTab.isSystemTrayConfig && panelTab._panelInfoMode === "simple" && (panelTab._simpleLayoutType !== 0 || panelTab.configRoot.cfg_panelSimpleHorizontalContent !== "icon_only")
+        Kirigami.FormData.label: i18n("Color by temperature:")
+        spacing: Kirigami.Units.smallSpacing
+        Switch {
+            checked: panelTab.configRoot.cfg_simpleTempColorDynamic
+            onToggled: panelTab.configRoot.cfg_simpleTempColorDynamic = checked
+
+            ToolTip.visible: hovered
+            ToolTip.text: i18n("Color the panel temperature with the same cold to hot scale as the forecast curve, instead of a fixed color.")
+            ToolTip.delay: Kirigami.Units.toolTipDelay
         }
     }
 

--- a/contents/ui/js/tempColors.js
+++ b/contents/ui/js/tempColors.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2026  Petar Nedyalkov
+ * Copyright 2026  rcspam
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as

--- a/contents/ui/js/tempColors.js
+++ b/contents/ui/js/tempColors.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026  Petar Nedyalkov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * tempColors.js — Shared temperature-to-color scale
+ *
+ * Single source of truth for the cold-to-hot gradient. Used by the forecast
+ * temperature curve, which paints it into a Canvas, and by the panel
+ * temperature, which needs a QML color, hence the two output helpers.
+ *
+ * Two sets of stops: bright ones stay readable on a dark background, deeper
+ * ones on a light background.
+ *
+ * Non-pragma JS — plain globals, imported with "as TempColorsJS".
+ */
+
+var STOPS_DARK = [
+    { t: -10, r:  50, g: 100, b: 255 },
+    { t:   0, r:   0, g: 180, b: 255 },
+    { t:  10, r:  80, g: 220, b: 160 },
+    { t:  20, r: 220, g: 220, b:  40 },
+    { t:  30, r: 255, g: 130, b:   0 },
+    { t:  40, r: 220, g:  30, b:  30 }
+];
+
+var STOPS_LIGHT = [
+    { t: -10, r:  20, g:  60, b: 200 },
+    { t:   0, r:   0, g: 120, b: 210 },
+    { t:  10, r:   0, g: 160, b:  80 },
+    { t:  20, r: 170, g: 150, b:   0 },
+    { t:  30, r: 210, g:  80, b:   0 },
+    { t:  40, r: 180, g:  10, b:  10 }
+];
+
+/**
+ * Interpolate the scale at a temperature.
+ *
+ * @param t     temperature in degrees Celsius
+ * @param dark  true when the color sits on a dark background
+ * @return      { r, g, b } with each channel in 0..255
+ */
+function rgbForTemperature(t, dark) {
+    var stops = dark ? STOPS_DARK : STOPS_LIGHT;
+    if (!isFinite(t) || t <= stops[0].t)
+        return { r: stops[0].r, g: stops[0].g, b: stops[0].b };
+    var last = stops[stops.length - 1];
+    if (t >= last.t)
+        return { r: last.r, g: last.g, b: last.b };
+    for (var i = 1; i < stops.length; i++) {
+        if (t <= stops[i].t) {
+            var a = stops[i - 1], b = stops[i];
+            var frac = (t - a.t) / (b.t - a.t);
+            return {
+                r: Math.round(a.r + frac * (b.r - a.r)),
+                g: Math.round(a.g + frac * (b.g - a.g)),
+                b: Math.round(a.b + frac * (b.b - a.b))
+            };
+        }
+    }
+    return { r: last.r, g: last.g, b: last.b };
+}
+
+/** CSS string for Canvas painting. */
+function cssForTemperature(t, dark) {
+    var c = rgbForTemperature(t, dark);
+    return "rgba(" + c.r + "," + c.g + "," + c.b + ",1.0)";
+}
+
+/** QML color for regular items. */
+function colorForTemperature(t, dark) {
+    var c = rgbForTemperature(t, dark);
+    return Qt.rgba(c.r / 255, c.g / 255, c.b / 255, 1.0);
+}
+
+/** True when a background color is dark enough to need the bright stops. */
+function isDarkBackground(bg) {
+    return (0.299 * bg.r + 0.587 * bg.g + 0.114 * bg.b) < 0.5;
+}


### PR DESCRIPTION
Hi,

I noticed not long ago that the panel temperature can be given a color. So I
thought it would be nice if that color followed the temperature curve colors
from the forecast.

It just adds a switch in the settings, off by default, so nothing changes for
anyone who does not turn it on. The only other thing is that the color scale
moved out of the forecast Canvas into `js/tempColors.js` with the same values,
so the curve and the panel share one scale instead of two copies.

If you find it cool, feel free to add this little contribution to your next
release.

Cheers