### PR TITLE
Offer the bundled icon themes in the Simple panel layout

### DIFF
--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -91,6 +91,11 @@ PlasmaCore.ToolTipArea {
     readonly property int simpleLayoutType: Plasmoid.configuration.panelSimpleLayoutType || 0
     readonly property int simpleWidgetOrder: Plasmoid.configuration.panelSimpleWidgetOrder || 0
     readonly property string simpleIconStyle: Plasmoid.configuration.panelSimpleIconStyle || "symbolic"
+    // Bundled SVG icon themes shipped under contents/icons/. They render like the
+    // colorful style (full cell, no color mask), only the artwork differs.
+    readonly property bool simpleIconIsBundled: compactRoot.simpleIconStyle === "symbolic-bundled"
+        || compactRoot.simpleIconStyle === "flat-color"
+        || compactRoot.simpleIconStyle === "3d-oxygen"
     readonly property string simpleClickAreaMode: Plasmoid.configuration.panelSimpleClickAreaMode || "auto"
     readonly property int simpleClickAreaSize: Math.max(20, Plasmoid.configuration.panelSimpleClickAreaSize || 96)
     readonly property bool simpleTempShadowEnabled: Plasmoid.configuration.panelSimpleTempShadowEnabled !== false
@@ -881,7 +886,7 @@ PlasmaCore.ToolTipArea {
                 // vertical auto  → fill available width up to the computed icon size
                 // vertical manual / horizontal → fixed square
                 // Base icon cell size from icon style and computed/manual size.
-                readonly property int _baseCellSz: compactRoot.simpleIconStyle === "colorful" ? compactRoot.simpleIconSz : compactRoot.simpleSymbolicIconSz
+                readonly property int _baseCellSz: (compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconIsBundled) ? compactRoot.simpleIconSz : compactRoot.simpleSymbolicIconSz
                 // On horizontal panels cap at panel height so the GridLayout row never
                 // expands beyond simpleGrid.height (prevents icon overflowing downward
                 // and temperature cell shifting).
@@ -945,7 +950,7 @@ PlasmaCore.ToolTipArea {
                     width: parent._cellSz
                     height: parent._cellSz
                     anchors.centerIn: parent
-                    visible: compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconStyle === "custom"
+                    visible: compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconStyle === "custom" || compactRoot.simpleIconIsBundled
                     source: compactRoot.weatherRoot ? compactRoot.weatherRoot.getSimpleModeIconSource() : ""
                     smooth: true
                 }
@@ -1047,7 +1052,7 @@ PlasmaCore.ToolTipArea {
                     width: parent.width
                     height: parent.height
                     anchors.centerIn: parent
-                    visible: compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconStyle === "custom"
+                    visible: compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconStyle === "custom" || compactRoot.simpleIconIsBundled
                     source: compactRoot.weatherRoot ? compactRoot.weatherRoot.getSimpleModeIconSource() : ""
                     smooth: true
                 }

--- a/contents/ui/CompactView.qml
+++ b/contents/ui/CompactView.qml
@@ -952,6 +952,11 @@ PlasmaCore.ToolTipArea {
                     anchors.centerIn: parent
                     visible: compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconStyle === "custom" || compactRoot.simpleIconIsBundled
                     source: compactRoot.weatherRoot ? compactRoot.weatherRoot.getSimpleModeIconSource() : ""
+                    // The bundled symbolic SVGs are drawn with fill="currentColor" and
+                    // stay invisible unless Kirigami tints them; the other bundled
+                    // themes carry their own colours.
+                    isMask: compactRoot.simpleIconStyle === "symbolic-bundled"
+                    color: compactRoot.simpleIconStyle === "symbolic-bundled" ? Kirigami.Theme.textColor : "transparent"
                     smooth: true
                 }
             }
@@ -1054,6 +1059,11 @@ PlasmaCore.ToolTipArea {
                     anchors.centerIn: parent
                     visible: compactRoot.simpleIconStyle === "colorful" || compactRoot.simpleIconStyle === "custom" || compactRoot.simpleIconIsBundled
                     source: compactRoot.weatherRoot ? compactRoot.weatherRoot.getSimpleModeIconSource() : ""
+                    // The bundled symbolic SVGs are drawn with fill="currentColor" and
+                    // stay invisible unless Kirigami tints them; the other bundled
+                    // themes carry their own colours.
+                    isMask: compactRoot.simpleIconStyle === "symbolic-bundled"
+                    color: compactRoot.simpleIconStyle === "symbolic-bundled" ? Kirigami.Theme.textColor : "transparent"
                     smooth: true
                 }
 

--- a/contents/ui/config/tabs/ConfigPanelTab.qml
+++ b/contents/ui/config/tabs/ConfigPanelTab.qml
@@ -317,6 +317,18 @@ Kirigami.FormLayout {
                     value: "symbolic"
                 },
                 {
+                    text: i18n("Symbolic (Bundled)"),
+                    value: "symbolic-bundled"
+                },
+                {
+                    text: i18n("Flat Color (Bundled)"),
+                    value: "flat-color"
+                },
+                {
+                    text: i18n("3D Oxygen (Bundled)"),
+                    value: "3d-oxygen"
+                },
+                {
                     text: i18n("Custom…"),
                     value: "custom"
                 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -1993,6 +1993,14 @@ PlasmoidItem {
             }
             return W.weatherCodeToIcon(code, night);
         }
+        // Bundled SVG themes: the style itself names the folder under contents/icons/.
+        // Only the 32 px variants are requested — every size folder holds the same
+        // artwork (identical viewBox), they differ only by the SVG width attribute,
+        // and Kirigami.Icon sizes the result itself.
+        if (style === "symbolic-bundled" || style === "flat-color" || style === "3d-oxygen") {
+            var bundledTheme = (style === "symbolic-bundled") ? "symbolic" : style;
+            return IconResolver.svgUrl(IconResolver._conditionSvgStem(code, night), 32, _iconsBaseDir, bundledTheme);
+        }
         if (style === "colorful" || theme === "kde" || theme === "custom")
             return W.weatherCodeToIcon(code, night);
         var iconSz = Plasmoid.configuration.panelIconSize || 22;


### PR DESCRIPTION
Closes #156

The Simple layout offered Colorful, Symbolic and Custom, while the other panel
layouts can also use the three bundled themes. This adds them to the Simple
picker so the same artwork is available everywhere.

Two commits:

- the three themes in the picker, resolved from the style itself and drawn in
  the full icon cell like Colorful is
- a tint for the bundled Symbolic, whose SVGs use `currentColor` and would stay
  invisible otherwise

Three files, under forty lines. Nothing outside the Simple layout changes, and
the other icon styles keep their current behaviour.