### PR TITLE
Stop providers from clobbering shared air-quality pollutants

### DIFF
--- a/contents/ui/WeatherService.qml
+++ b/contents/ui/WeatherService.qml
@@ -155,6 +155,16 @@ QtObject {
     // fall back to AlertsJS without having to blank weatherRoot.weatherAlerts
     // up front (which would hide a still-valid alert for the fetch duration).
     property bool _nativeAlertsSetThisGen: false
+    // True once the selected provider has written a native air-quality index
+    // for this refresh generation. The shared Open-Meteo air-quality fetch
+    // always runs alongside it, and uses this flag to contribute only the
+    // pollutant concentrations rather than overwriting the provider's index.
+    property bool _nativeAqiSetThisGen: false
+    // Per-generation accumulator behind _mergeAqiData(), which merges the
+    // provider's index with the shared Open-Meteo fetch's pollutants instead
+    // of letting the later response overwrite the earlier one.
+    property var _aqiAccum: null
+    property int _aqiAccumGen: -1
 
     // Safety timer — if loading stays true for 20 s, force-reset state
     // so the widget never gets stuck in "Loading…" forever.
@@ -205,6 +215,7 @@ QtObject {
         // alert from the UI for the whole duration of the fetch. The provider
         // (or the AlertsJS fallback) replaces it once new data is actually in.
         _nativeAlertsSetThisGen = false;
+        _nativeAqiSetThisGen = false;
 
         var provider = Plasmoid.configuration.weatherProvider || "adaptive";
         var chain = (provider === "adaptive") ? ["openMeteo", "bbc", "metno", "pirateWeather", "visualCrossing", "tomorrowIo", "stormGlass", "weatherbit", "qWeather", "openWeather", "weatherApi"] : [provider];
@@ -889,6 +900,53 @@ QtObject {
     // ─── Shared Open-Meteo air-quality + pollen fallback ────────────────────
 
     /**
+     * Merges a partial air-quality patch into weatherRoot.aqiDataStaged.
+     *
+     * Two independent sources write air-quality data on every refresh: the
+     * selected provider (index + label, on its own scale) and the shared
+     * Open-Meteo fetch below (the six pollutant concentrations). They race,
+     * so a plain assignment lets whichever response lands second discard the
+     * other's fields — which is what used to leave PM2.5 and the rest of the
+     * pollutant rows showing "--" under OpenWeather / WeatherAPI / QWeather.
+     *
+     * Ownership is therefore split: providers merge {index, label} and set
+     * _nativeAqiSetThisGen; the shared fetch merges the pollutants and only
+     * fills in the index when no provider claimed it. Neither clobbers the
+     * other regardless of arrival order.
+     *
+     * At the start of each refresh generation the accumulator is seeded from
+     * the data already on screen rather than from an empty object, so the
+     * card doesn't flash "--" between the first and second response of the
+     * new generation (same reasoning as weatherAlerts in refreshNow()). A
+     * successful shared fetch rewrites all six pollutant keys, so a stale
+     * reading only survives a fetch that failed outright.
+     */
+    function _mergeAqiData(patch) {
+        if (!patch)
+            return;
+        if (_aqiAccumGen !== _refreshGen) {
+            _aqiAccum = weatherRoot.aqiData || {};
+            _aqiAccumGen = _refreshGen;
+        }
+        var merged = {};
+        var k;
+        for (k in _aqiAccum)
+            merged[k] = _aqiAccum[k];
+        for (k in patch) {
+            if (patch[k] === undefined)
+                continue;
+            merged[k] = patch[k];
+        }
+        _aqiAccum = merged;
+        // Hand the staging property a fresh object — QML compares by
+        // reference, so mutating the accumulator in place would not notify.
+        var out = {};
+        for (k in merged)
+            out[k] = merged[k];
+        weatherRoot.aqiDataStaged = out;
+    }
+
+    /**
      * Fetches AQI, pollutant concentrations, and pollen from the Open-Meteo
      * air-quality API and writes them into weatherRoot.
      * Called by providers that don't supply this data natively.
@@ -922,9 +980,10 @@ QtObject {
                     else if (aqi <= 100) label = "Very Poor";
                     else                 label = "Hazardous";
                 }
-                r.aqiDataStaged = {
-                    index: (aqi !== undefined) ? aqi : NaN,
-                    label: label,
+                // Pollutants always come from here — they are the only source
+                // the UI's per-pollutant sub-index bars have. The index is
+                // contributed only when the provider did not supply its own.
+                var patch = {
                     pm10:  (c.pm10            !== undefined) ? c.pm10            : NaN,
                     pm2_5: (c.pm2_5           !== undefined) ? c.pm2_5           : NaN,
                     no2:   (c.nitrogen_dioxide !== undefined) ? c.nitrogen_dioxide : NaN,
@@ -932,6 +991,11 @@ QtObject {
                     o3:    (c.ozone            !== undefined) ? c.ozone            : NaN,
                     co:    (c.carbon_monoxide  !== undefined) ? c.carbon_monoxide / 1000.0 : NaN
                 };
+                if (!_nativeAqiSetThisGen) {
+                    patch.index = (aqi !== undefined) ? aqi : NaN;
+                    patch.label = label;
+                }
+                _mergeAqiData(patch);
                 var pollenKeys = [
                     { key: "alder",   field: "alder_pollen"   },
                     { key: "birch",   field: "birch_pollen"   },

--- a/contents/ui/providers/openWeather.js
+++ b/contents/ui/providers/openWeather.js
@@ -160,14 +160,19 @@ function _owAqiLabel(aqi) {
     return "";
 }
 
+/**
+ * OpenWeather supplies only its own 1–5 index here, not the pollutant
+ * concentrations the details card charts. Those arrive from the shared
+ * Open-Meteo air-quality fetch that WeatherService.refreshNow() runs in
+ * parallel, so every exit path below leaves weatherRoot.aqiData alone
+ * rather than nulling it — clearing it here would race that fetch and
+ * blank the pollutant rows depending on which response landed last.
+ */
 function _fetchAirQuality(service, W) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
     var key = service._owKey();
-    if (!key) {
-        r.aqiData = null;
+    if (!key)
         return;
-    }
     var url = "https://api.openweathermap.org/data/2.5/air_pollution?lat="
         + service.latitude + "&lon=" + service.longitude
         + "&appid=" + encodeURIComponent(key);
@@ -177,19 +182,16 @@ function _fetchAirQuality(service, W) {
         if (req.readyState !== XMLHttpRequest.DONE)
             return;
         if (service._refreshGen !== gen) return;
-        if (req.status !== 200) {
-            r.aqiData = null;
-            r.pollenData = [];
+        if (req.status !== 200)
             return;
-        }
         var d = JSON.parse(req.responseText);
         if (d.list && d.list.length > 0 && d.list[0].main) {
             var aqi = d.list[0].main.aqi;
-            r.aqiDataStaged = { index: aqi, label: _owAqiLabel(aqi) };
-        } else {
-            r.aqiData = null;
+            service._mergeAqiData({ index: aqi, label: _owAqiLabel(aqi) });
+            service._nativeAqiSetThisGen = true;
         }
-        r.pollenData = []; // not available in OpenWeather free tier
+        // Pollen is not available in the OpenWeather free tier; the shared
+        // Open-Meteo fetch supplies it.
     };
     req.send();
 }

--- a/contents/ui/providers/pirateWeather.js
+++ b/contents/ui/providers/pirateWeather.js
@@ -171,10 +171,9 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  day0 && day0.sunsetTime  ? Qt.formatTime(new Date(day0.sunsetTime  * 1000), "HH:mm") : "--",
             dailyData:       nd
         };
-        // Air quality is now fetched natively — see fetchAirQuality() below.
-        // (Previously this line nulled r.aqiData out immediately, since PW
-        // had no AQI support and the shared/universal fetch owned this field.)
-        r.pollenData = [];
+        // No native air quality or pollen — both are supplied by the shared
+        // Open-Meteo fetch started in WeatherService.refreshNow(). Clearing
+        // them here would race that fetch and discard its result.
         r.loading = false;
         r.updateText = service._formatUpdateText("pirateWeather");
 
@@ -344,19 +343,20 @@ function _aqiBandKey(index) {
  * concentrations (pm25/pm10 in µg/m³, the rest in ppb) don't change with
  * units, so this request is intentionally scoped to `currently` only.
  *
- * Gas concentrations are converted ppb -> µg/m³ to match pm10/pm2_5 and
- * (assumed) what AQI.js's per-pollutant bands expect — flag this if your
- * AQI.js actually wants ppb or mg/m³ for CO, and the conversion can be
- * dropped or adjusted.
+ * Gas concentrations are converted ppb -> µg/m³ to match pm10/pm2_5, which
+ * is what airQuality.js's per-pollutant bands expect for o3/no2/so2. CO is
+ * the exception: its band table is in mg/m³, so it takes a further /1000.
+ *
+ * NOTE: this function is not currently dispatched from Providers.qml — Pirate
+ * Weather's air quality is served by the shared Open-Meteo fetch like every
+ * other provider's. It is kept here, conforming to the _mergeAqiData()
+ * contract, for whenever the native path is wired up.
  */
 function fetchAirQuality(service, W) {
     var gen = service._refreshGen;
-    var r = service.weatherRoot;
     var key = service._pwKey();
-    if (!key) {
-        service._fetchAqiIfNeeded();
+    if (!key)
         return;
-    }
 
     var url = "https://api.pirateweather.net/forecast/"
         + encodeURIComponent(key) + "/"
@@ -370,25 +370,21 @@ function fetchAirQuality(service, W) {
         if (req.readyState !== XMLHttpRequest.DONE)
             return;
         if (service._refreshGen !== gen) return;
-        if (req.status !== 200) {
-            service._fetchAqiIfNeeded();
+        if (req.status !== 200)
             return;
-        }
         try {
             var d = JSON.parse(req.responseText);
         } catch (e) {
-            service._fetchAqiIfNeeded();
             return;
         }
 
         var c = d.currently;
         // -999 is PW's sentinel for "not available at this location/time"
-        if (!c || c.airQualityIndex === undefined || c.airQualityIndex === -999) {
-            service._fetchAqiIfNeeded();
+        if (!c || c.airQualityIndex === undefined || c.airQualityIndex === -999)
             return;
-        }
 
-        r.aqiDataStaged = {
+        var co = _ppbToUgm3(c.coConcentration, _MOLAR_MASS.co);
+        service._mergeAqiData({
             index: c.airQualityIndex,
             label: _aqiBandKey(c.airQualityIndex),
             pm10:  (c.pm10 !== undefined) ? c.pm10 : NaN,
@@ -396,15 +392,9 @@ function fetchAirQuality(service, W) {
             o3:    _ppbToUgm3(c.ozoneConcentration, _MOLAR_MASS.o3),
             no2:   _ppbToUgm3(c.no2Concentration, _MOLAR_MASS.no2),
             so2:   _ppbToUgm3(c.so2Concentration, _MOLAR_MASS.so2),
-            co:    _ppbToUgm3(c.coConcentration, _MOLAR_MASS.co)
-        };
-
+            co:    isNaN(co) ? NaN : co / 1000.0   // airQuality.js bands CO in mg/m³
+        });
         service._nativeAqiSetThisGen = true;
-
-        // Mirrors _fetchAlertsIfNeeded(): call unconditionally so the
-        // shared/universal AQI source only fills in when PW didn't
-        // deliver native data this generation.
-        service._fetchAqiIfNeeded();
     };
     req.send();
 }

--- a/contents/ui/providers/qWeather.js
+++ b/contents/ui/providers/qWeather.js
@@ -271,8 +271,14 @@ function _qwAqiLabel(category) {
     return "";
 }
 
+/**
+ * QWeather contributes only its own index here. The pollutant concentrations
+ * charted by the details card come from the shared Open-Meteo air-quality
+ * fetch running in parallel, so the exit paths below leave
+ * weatherRoot.aqiData untouched instead of nulling it — clearing it would
+ * race that fetch and blank the pollutant rows.
+ */
 function _fetchAirQuality(service, W, key, loc, gen, base) {
-    var r = service.weatherRoot;
     var url = base + "/airquality/v1/current?location=" + encodeURIComponent(loc);
 
     var req = new XMLHttpRequest();
@@ -281,25 +287,20 @@ function _fetchAirQuality(service, W, key, loc, gen, base) {
     req.onreadystatechange = function () {
         if (req.readyState !== XMLHttpRequest.DONE) return;
         if (service._refreshGen !== gen) return;
-        if (req.status !== 200) {
-            r.aqiData = null;
-            r.pollenData = [];
+        if (req.status !== 200)
             return;
-        }
         var d;
         try { d = JSON.parse(req.responseText); } catch (e) {
-            r.aqiData = null;
-            r.pollenData = [];
             return;
         }
         if (d.code === "200" && d.indexes && d.indexes.length > 0) {
             var idx = d.indexes[0];
-            var aqi = parseFloat(idx.aqiDisplay) || NaN;
-            r.aqiDataStaged = { index: aqi, label: _qwAqiLabel(parseInt(idx.category, 10)) };
-        } else {
-            r.aqiData = null;
+            var aqi = parseFloat(idx.aqiDisplay);
+            if (!isNaN(aqi)) {
+                service._mergeAqiData({ index: aqi, label: _qwAqiLabel(parseInt(idx.category, 10)) });
+                service._nativeAqiSetThisGen = true;
+            }
         }
-        r.pollenData = [];
     };
     req.send();
 }

--- a/contents/ui/providers/stormGlass.js
+++ b/contents/ui/providers/stormGlass.js
@@ -196,8 +196,9 @@ function fetchCurrent(service, W, chain, idx) {
         }
         _cur.dailyData = nd;
         r.weatherDataStaged = _cur;
-        r.aqiData = null;
-        r.pollenData = [];
+        // No native air quality or pollen — both are supplied by the shared
+        // Open-Meteo fetch started in WeatherService.refreshNow(). Clearing
+        // them here would race that fetch and discard its result.
         r.loading = false;
         r.updateText = service._formatUpdateText("stormGlass");
 

--- a/contents/ui/providers/tomorrowIo.js
+++ b/contents/ui/providers/tomorrowIo.js
@@ -113,8 +113,9 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  "--",
             dailyData:       []
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        // No native air quality or pollen — both are supplied by the shared
+        // Open-Meteo fetch started in WeatherService.refreshNow(). Clearing
+        // them here would race that fetch and discard its result.
         // Step 2: Fetch daily forecast for dailyData + sun times, then write r.weatherData
         _fetchForecast(service, W, gen);
     };

--- a/contents/ui/providers/visualCrossing.js
+++ b/contents/ui/providers/visualCrossing.js
@@ -153,8 +153,9 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  c.sunset  ? c.sunset.substring(0, 5)  : "--",
             dailyData:       nd
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        // No native air quality or pollen — both are supplied by the shared
+        // Open-Meteo fetch started in WeatherService.refreshNow(). Clearing
+        // them here would race that fetch and discard its result.
         r.loading = false;
         r.updateText = service._formatUpdateText("visualCrossing");
 

--- a/contents/ui/providers/weatherApi.js
+++ b/contents/ui/providers/weatherApi.js
@@ -97,14 +97,17 @@ function fetchCurrent(service, W, chain, idx) {
             service._tryProvider(chain, idx + 1);
             return;
         }
+        // Only the index is contributed here — the pollutant concentrations
+        // and pollen come from the shared Open-Meteo air-quality fetch that
+        // runs in parallel. Merging (rather than assigning aqiData) keeps
+        // whichever of the two responses lands second from dropping the
+        // other's fields.
         var aq = d.current.air_quality;
         var epa = aq ? aq["us-epa-index"] : undefined;
-        if (aq) {
-            r.aqiDataStaged = { index: (epa !== undefined) ? epa : NaN, label: _waAqiLabel(epa) };
-        } else {
-            r.aqiData = null;
+        if (epa !== undefined) {
+            service._mergeAqiData({ index: epa, label: _waAqiLabel(epa) });
+            service._nativeAqiSetThisGen = true;
         }
-        r.pollenData = [];
         var astro = (d.forecast && d.forecast.forecastday && d.forecast.forecastday.length > 0)
             ? d.forecast.forecastday[0].astro : null;
         var nd = [];

--- a/contents/ui/providers/weatherbit.js
+++ b/contents/ui/providers/weatherbit.js
@@ -118,8 +118,9 @@ function fetchCurrent(service, W, chain, idx) {
             sunsetTimeText:  c.sunset  || "--",
             dailyData:       []
         };
-        r.aqiData = null;
-        r.pollenData = [];
+        // No native air quality or pollen — both are supplied by the shared
+        // Open-Meteo fetch started in WeatherService.refreshNow(). Clearing
+        // them here would race that fetch and discard its result.
         _fetchDailyForecast(service, W, gen);
     };
     req.send();


### PR DESCRIPTION
## The problem

`WeatherService._fetchAirQualityOpenMeteo()` runs on every refresh regardless of the selected provider, and it is the **only** source of the six pollutant concentrations that the expanded Air Quality card charts (`DetailsView.qml` `aqiRootPollutants` → `AQI.subIndex(...)`).

Providers that also produce air quality assigned `weatherRoot.aqiData` / `aqiDataStaged` outright, so the two in-flight requests raced and whichever HTTP response landed second discarded the other's fields:

- **OpenWeather, WeatherAPI, QWeather** write `{index, label}` with no pollutants. When their response lands after Open-Meteo's, PM2.5 / PM10 / NO₂ / O₃ / SO₂ / CO all fall back to `--`, the band badge and tooltip hide, and the bar sits at 0 — while the row still occupies its 48 px, so it reads as broken rather than switched off.
- **Visual Crossing, Weatherbit, Tomorrow.io, StormGlass, Pirate Weather** ran `r.aqiData = null; r.pollenData = [];` on every *successful* fetch. That doesn't just drop pollutants — it removes the entire Air Quality card and all pollen whenever the provider wins the race. Two of them already carried a comment saying air quality comes from the shared fetch.

Because it depends on response ordering, the symptom is intermittent and looks location- or network-dependent.

## The fix

Split ownership instead of racing.

- New `WeatherService._mergeAqiData(patch)` accumulates partial patches per refresh generation and hands `aqiDataStaged` a fresh object (QML compares by reference, so the accumulator is never mutated in place).
- New `_nativeAqiSetThisGen` records that a provider claimed the index, mirroring the existing `_nativeAlertsSetThisGen` pattern.
- Providers with a native index merge `{index, label}` and set the flag. The shared Open-Meteo fetch merges the pollutants and fills in the index **only** when no provider claimed it.
- Providers without native air quality no longer null the fields.

Arrival order no longer changes the outcome in either direction.

| Source | Writes | Never touches |
|---|---|---|
| Provider with native index | `{index, label}` + flag | pollutants, pollen |
| Shared Open-Meteo fetch | 6 pollutants + pollen; index only if unclaimed | — |
| Providers without native AQI | nothing | everything |

At the start of a generation the accumulator seeds from the data already on screen rather than from an empty object, so the card does not flash `--` between the first and second response of a refresh — the same reasoning already applied to `weatherAlerts` in `refreshNow()`. A successful shared fetch rewrites all six pollutant keys, so a stale reading only survives a fetch that failed outright.

### Also in this commit

`pirateWeather.fetchAirQuality()` is brought onto the same contract. It is not dispatched from `Providers.qml`, so it never ran — but as written it called `service._fetchAqiIfNeeded()`, which does not exist anywhere in the codebase, on all five of its exit paths. It would have thrown a `ReferenceError` the moment it was wired up. Its CO was also reported in µg/m³ where `airQuality.js` bands CO in mg/m³ (~1000× off). Both corrected; still left undispatched, with a note saying so. Happy to drop this part if you'd rather finish that path yourself.

## Testing

**Merge logic — 14/14.** A harness extracts `_mergeAqiData` from `WeatherService.qml` at run time by brace balance (rather than re-typing it, so it cannot drift) and drives it through: Open-Meteo-first, provider-first, no-native-provider, generation rollover, explicit `NaN` from a later response, and object-reference identity for QML change notification.

**Live run.** The widget was run under `plasmawindowed` against real Open-Meteo data with `_applyAqiData` instrumented, on an isolated `XDG_DATA_HOME`/`XDG_CONFIG_HOME`:

```
qml: AQITEST {"pm10":13,"pm2_5":9.7,"no2":7.8,"so2":2.2,"o3":92,"co":0.156,"index":37,"label":"Fair"}
```

All six pollutants populated. The field order is itself evidence of the new path — pollutants from the patch literal, `index`/`label` appended by the `if (!_nativeAqiSetThisGen)` branch. No `ReferenceError`/`TypeError`; no errors referencing any package file. `qmllint` is clean on `WeatherService.qml`, and all eight edited provider files parse.

**What I could not verify:** the three providers whose responses trigger the reported symptom (OpenWeather, WeatherAPI, QWeather) all gate their fetch behind an API key, as do the four whose clobber is removed here. I have keys for none of them, so those paths are proven at the algorithm level only, not end-to-end. If you can run one keyed provider and confirm the PM2.5 row populates, that closes the gap.

## Known issue this does *not* address

Three providers write mutually incompatible index scales into the same field that the UI bands as EU CAQI 0–150: OpenWeather a 1–5 index, WeatherAPI a 1–6 US-EPA index, QWeather a China-AQI value. After this PR their *pollutant rows* are correct, but the headline AQI number and its colour are still wrong — with those providers the card reads "Good" almost always. That needs a per-source scale tag or normalisation, which felt like a separate change. Related: the band thresholds differ between `WeatherService.qml` / `openMeteo.js` (20/40/60/80/100) and `airQuality.js` / `main.qml` (25/50/75/100/150). Glad to open a follow-up if useful.
