### PR TITLE
Let the user point the radar at a self-hosted LibreWXR server

### DIFF
--- a/contents/ui/config/configGeneral.qml
+++ b/contents/ui/config/configGeneral.qml
@@ -39,6 +39,7 @@ KCM.SimpleKCM {
     property string cfg_qwApiHost: ""
     property bool cfg_radarEnabled: true
     property string cfg_radarProvider: "rainviewer"
+    property string cfg_librewxrUrl: "https://api.librewxr.net"
     property bool cfg_radarGpuWorkaround: false
     property string cfg_alertsProvider: "native"
     property string cfg_fossAlertUrl: "https://alerts.kde.org"
@@ -857,6 +858,35 @@ KCM.SimpleKCM {
                 type: Kirigami.MessageType.Information
                 text: i18n("Radar provider: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/>" + "LibreWXR is a free, open-source weather radar API. It combines real radar composites from NOAA, Canadian, and European sources with a global model fallback, and provides the past 2 hours of radar data plus a short nowcast. It also offers a free satellite (infrared) layer.<br/><br/>" + "Layer mode, radar color scheme, and motion arrows are selected directly in the Radar tab. The map follows your Plasma light/dark theme automatically.")
                 onLinkActivated: Qt.openUrlExternally(link)
+            }
+
+            // LibreWXR is self-hostable, so let the user point the radar and the
+            // alerts provider at their own instance instead of the public API.
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: 8
+                spacing: 8
+                visible: root.cfg_radarEnabled && root.cfg_radarProvider === "librewxr"
+
+                Label {
+                    text: i18n("LibreWXR server:")
+                    font.bold: true
+                }
+                Label {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    opacity: 0.7
+                    text: i18n("Leave this empty to use the public server. Set it to your own address if you run a self-hosted LibreWXR instance.")
+                }
+                TextField {
+                    id: librewxrUrlField
+                    Layout.fillWidth: true
+                    placeholderText: "https://api.librewxr.net"
+                    text: root.cfg_librewxrUrl
+                    selectByMouse: true
+                    onTextEdited: root.cfg_librewxrUrl = text
+                    onEditingFinished: root.cfg_librewxrUrl = text.trim()
+                }
             }
 
             Kirigami.InlineMessage {


### PR DESCRIPTION
Closes #175.

The `librewxrUrl` config entry already exists and already works. The radar view, WeatherService and the alerts provider all read it, and an empty value falls back to the public API. The only thing missing is a way to set it: nothing in the settings exposes it, so today the only way to reach your own instance is to hand-edit `plasma-org.kde.plasma.desktop-appletsrc`.

This adds a text field for it under the radar provider, shown only when LibreWXR is the selected provider, in the same shape as the QWeather API host field just above. Empty keeps the public server, so nothing changes for anyone who doesn't touch it.

LibreWXR advertises itself as self-hostable and it's a genuinely useful thing to do, a local instance renders tiles in a few milliseconds against several hundred on the public server, so the radar animation stops being the slow part of the widget.

One file, `contents/ui/config/configGeneral.qml`, nothing else touched.