### PR TITLE
Show a sun in the afternoon: derive day/night from sunrise and sunset

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -2054,11 +2054,12 @@ PlasmoidItem {
     }
 
     function isNightTime() {
-        // Prefer the API-reported is_day flag — accurate on first load
-        // before sunrise/sunset strings have been populated.
-        if (isDay >= 0)
-            return isDay === 0;
-        // Fallback: derive from stored sunrise/sunset times.
+        // Derive from sunrise/sunset first. This is what the forecast strip
+        // already does when it picks its own icons (ForecastView.qml), so
+        // going through the same route keeps the condition icon and the
+        // forecast below it in agreement. Trusting the provider's day/night
+        // flag ahead of these is what let BBC's `isNight` put a moon on a
+        // sunny afternoon while the forecast right underneath showed suns.
         var now = new Date();
         var nowMins = now.getHours() * 60 + now.getMinutes();
         function parseMins(t) {
@@ -2069,9 +2070,14 @@ PlasmoidItem {
         }
         var rise = parseMins(sunriseTimeText);
         var set_ = parseMins(sunsetTimeText);
-        if (rise < 0 || set_ < 0)
-            return false;
-        return nowMins < rise || nowMins >= set_;
+        if (rise >= 0 && set_ >= 0)
+            return nowMins < rise || nowMins >= set_;
+        // Fallback: the API-reported is_day flag, which is still the only
+        // thing available on first load, before the sunrise/sunset strings
+        // have been populated.
+        if (isDay >= 0)
+            return isDay === 0;
+        return false;
     }
 
     // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
My widget showed a moon all afternoon on a clear sunny day, with the forecast strip right underneath showing suns.

The two decide day and night differently. `isNightTime()` trusts the provider's flag first; `ForecastView.qml` derives it from the hour against sunrise/sunset. Honest providers agree, so it never showed.

BBC doesn't. Queried at 18:21 local for a French location, one response:

```
isNight     : true
sunset      : 21:00
weatherType : 1 (Sunny)
```

Two fields say daylight, we read the third.

Fix swaps the order in `isNightTime()`: sunrise/sunset when both parse, API flag as fallback for first load, which is the only case the old comment justified it for. Ten cases checked across both orderings, every provider style and first load: one result changes, the BBC one.

Left alone deliberately: both routes compare the local machine clock to the location's sun times, so another timezone still gets the wrong half of the day. Separate, older bug.