### PR TITLE
UI: shorten the unsupported-field label to N/A

### DIFF
--- a/contents/ui/ForecastView.qml
+++ b/contents/ui/ForecastView.qml
@@ -1288,7 +1288,7 @@ Item {
                                                         visible: !parent._isSun
                                                         text: {
                                                             var uv = modelData.uvIndex;
-                                                            if (W.isNotSupported(uv)) return i18n("Not supported");
+                                                            if (W.isNotSupported(uv)) return i18n("N/A");
                                                             return (uv === undefined || isNaN(uv)) ? "--" : "UV " + uv.toFixed(1);
                                                         }
                                                         color: forecastRoot.themeTextColor
@@ -1735,7 +1735,7 @@ Item {
                                                                 Label {
                                                                     text: {
                                                                         var uv = modelData.uvIndex;
-                                                                        if (W.isNotSupported(uv)) return i18n("Not supported");
+                                                                        if (W.isNotSupported(uv)) return i18n("N/A");
                                                                         return (uv === undefined || isNaN(uv)) ? "--" : "UV " + uv.toFixed(1);
                                                                     }
                                                                     color: forecastRoot.themeTextColor

--- a/contents/ui/js/weather.js
+++ b/contents/ui/js/weather.js
@@ -36,7 +36,7 @@ function I18N_NOOP(s) { return s; }
 // (transient) — formatters render that as "--". Some providers, however, never
 // expose a given field at all (e.g. BBC has no precipitation amount and no
 // per-hour UV index). Those providers set the field to NOT_SUPPORTED so the
-// formatters can render a distinct, honest "Not supported" instead of "--".
+// formatters can render a distinct, honest "N/A" instead of "--".
 var NOT_SUPPORTED = -9999;
 function isNotSupported(v) { return v === NOT_SUPPORTED; }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -755,7 +755,7 @@ PlasmoidItem {
         return Plasmoid.configuration.temperatureUnit || "C";
     }
     function tempValue(celsius, context) {
-        if (W.isNotSupported(celsius)) return i18n("Not supported");
+        if (W.isNotSupported(celsius)) return i18n("N/A");
         var unit = _tempUnit();
         var primary = W.formatTemp(celsius, unit, Plasmoid.configuration.roundValues, Plasmoid.configuration.showTempUnit);
         if (!Plasmoid.configuration.dualTempEnabled) return primary;
@@ -788,7 +788,7 @@ PlasmoidItem {
         return Plasmoid.configuration.pressureUnit || "hPa";
     }
     function pressureValue(hpa) {
-        if (W.isNotSupported(hpa)) return i18n("Not supported");
+        if (W.isNotSupported(hpa)) return i18n("N/A");
         if (isNaN(hpa) || hpa === null || hpa === undefined) return "--";
         var unit = _pressureUnit();
         return W.formatPressureValue(hpa, unit) + " " + i18n(W.pressureUnitLabel(unit));
@@ -801,7 +801,7 @@ PlasmoidItem {
     }
 
     function precipValue(mmh) {
-        if (W.isNotSupported(mmh)) return i18n("Not supported");
+        if (W.isNotSupported(mmh)) return i18n("N/A");
         if (isNaN(mmh)) return "--";
         if (_isImperial())
             return (mmh / 25.4).toFixed(2) + " " + i18n("in/h");
@@ -809,7 +809,7 @@ PlasmoidItem {
     }
 
     function precipSumText(mm) {
-        if (W.isNotSupported(mm)) return i18n("Not supported");
+        if (W.isNotSupported(mm)) return i18n("N/A");
         if (isNaN(mm)) return "--";
         if (_isImperial())
             return (mm / 25.4).toFixed(2) + " " + i18n("in");
@@ -817,7 +817,7 @@ PlasmoidItem {
     }
 
     function visibilityValue(km) {
-        if (W.isNotSupported(km)) return i18n("Not supported");
+        if (W.isNotSupported(km)) return i18n("N/A");
         if (isNaN(km)) return "--";
         if (_isImperial())
             return (km * 0.621371).toFixed(1) + " " + i18n("mi");
@@ -845,7 +845,7 @@ PlasmoidItem {
     }
 
     function uvIndexText(uv) {
-        if (W.isNotSupported(uv)) return i18n("Not supported");
+        if (W.isNotSupported(uv)) return i18n("N/A");
         if (isNaN(uv)) return "--";
         var v = Math.round(uv * 10) / 10;
         if (v <= 2) return v + " (" + i18n("Low") + ")";

--- a/translate/template.pot
+++ b/translate/template.pot
@@ -2102,6 +2102,12 @@ msgstr ""
 msgid "Multiple lines (tall panel)"
 msgstr ""
 
+#: contents/ui/ForecastView.qml:1291 contents/ui/ForecastView.qml:1738
+#: contents/ui/main.qml:758 contents/ui/main.qml:791 contents/ui/main.qml:804
+#: contents/ui/main.qml:812 contents/ui/main.qml:820 contents/ui/main.qml:848
+msgid "N/A"
+msgstr ""
+
 #: contents/ui/config/configAppearance.qml:1426
 #: contents/ui/config/configAppearance.qml:1549
 #: contents/ui/config/configAppearance.qml:1672
@@ -2204,12 +2210,6 @@ msgstr ""
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:363
 msgid "Not available: the selected base map already has a fixed light or dark style."
-msgstr ""
-
-#: contents/ui/ForecastView.qml:1291 contents/ui/ForecastView.qml:1738
-#: contents/ui/main.qml:758 contents/ui/main.qml:791 contents/ui/main.qml:804
-#: contents/ui/main.qml:812 contents/ui/main.qml:820 contents/ui/main.qml:848
-msgid "Not supported"
 msgstr ""
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:623


### PR DESCRIPTION
`"Not supported"` is a long string for the places it lands. The per-hour UV row
and the precipitation row of the hourly strip are narrow columns, and the label
repeats on every hour. BBC is the provider that triggers it, with no
precipitation amount at all and no per-hour UV index.

`N/A` keeps the distinction the sentinel exists for — `--` means the value has
not loaded yet, `N/A` means this provider never exposes it — in three characters
instead of a phrase.

### Changes

- `ForecastView.qml`: the two per-hour UV labels
- `main.qml` : the six formatters (temperature, pressure, precipitation rate and
  amount, visibility, UV index)
- `weather.js` : the comment describing what the sentinel renders as
- `template.pot` : the msgid, moved to its `--sort-output` position

### Translation catalogs

The `.po` files are left untouched on purpose: `N/A` is absent from them, so
gettext returns the msgid and every language shows `N/A`. Translators can add a
localised form later where one is customary.
