### PR TITLE
Add OpenFreeMap alongside CARTO, with an optional CARTO API key

### DIFF
--- a/contents/ui/components/MapBackgroundChoices.qml
+++ b/contents/ui/components/MapBackgroundChoices.qml
@@ -44,8 +44,8 @@ QtObject {
         "osm-humanitarian": i18n("Humanitarian (HOT)"),
         "cyclosm": i18n("CyclOSM (cycling)"),
         "opentopomap": i18n("OpenTopoMap (topographic)"),
-        "carto-positron": i18n("Carto Positron (light)"),
-        "carto-darkmatter": i18n("Carto Dark Matter (dark)")
+        "openfreemap-positron": i18n("OpenFreeMap Positron (light)"),
+        "openfreemap-dark": i18n("OpenFreeMap Dark")
     })
 
     /** Choices plus their resolved tile data, ready to inject into a page. */
@@ -58,7 +58,9 @@ QtObject {
             out.push({
                 id: id,
                 label: choices.labels[id] || id,
-                url: p.tileUrlTemplate,
+                url: p.tileUrlTemplate || "",
+                styleUrl: p.styleUrl || "",
+                vector: MapProvidersJS.isVectorBackground(p),
                 attribution: p.attribution + choices.attributionSuffix,
                 maxZoom: p.maxZoom
             });

--- a/contents/ui/components/MapBackgroundChoices.qml
+++ b/contents/ui/components/MapBackgroundChoices.qml
@@ -45,6 +45,8 @@ QtObject {
         "cyclosm": i18n("CyclOSM (cycling)"),
         "opentopomap": i18n("OpenTopoMap (topographic)"),
         "openfreemap-positron": i18n("OpenFreeMap Positron (light)"),
+        "openfreemap-liberty": i18n("OpenFreeMap Liberty (light)"),
+        "openfreemap-fiord": i18n("OpenFreeMap Fiord (dark)"),
         "openfreemap-dark": i18n("OpenFreeMap Dark")
     })
 

--- a/contents/ui/components/RadarWebEngineView.qml
+++ b/contents/ui/components/RadarWebEngineView.qml
@@ -143,7 +143,10 @@ Item {
         var owmKeyJs   = JSON.stringify(owmKey || "");
         var layerJs    = JSON.stringify(layer  || "rainviewer");
         var baseMap    = MapProvidersJS.resolveMapBackground(mapBackground);
-        var baseUrlJs  = JSON.stringify(baseMap.tileUrlTemplate);
+        // A vector background has no raster template; the page starts on plain
+        // OSM tiles and swaps itself over once MapLibre has loaded.
+        var baseUrlJs  = JSON.stringify(baseMap.tileUrlTemplate
+                                        || MapProvidersJS.MAP_BACKGROUNDS[MapProvidersJS.DEFAULT_MAP_BACKGROUND].tileUrlTemplate);
         var baseAttrJs = JSON.stringify(baseMap.attribution);
         var bgListJs   = radarRoot.backgroundChoices.toJson();
         var bgCurrJs   = JSON.stringify(mapBackground || "auto");
@@ -282,6 +285,13 @@ var baseLayer = L.tileLayer(BASE_TILE_URL, {\
 }).addTo(map);\
 \
 L.marker([LAT, LON]).addTo(map);\
+\
+/* baseLayer above is always raster. If the saved background is a vector style,\
+   fetch MapLibre and swap it in; applyBackground is hoisted, BG_LIST is set. */\
+(function() {\
+    var e0 = bgEntry(BG_CURRENT);\
+    if (e0 && e0.vector && e0.styleUrl) loadMapLibre(function() { applyBackground(BG_CURRENT); });\
+})();\
 \
 var apiData = {};\
 var mapFrames = [];\
@@ -520,15 +530,49 @@ function updateBaseDim() {\
     else c.classList.remove("base-dimmed");\
 }\
 \
+/* MapLibre is only fetched when a vector background is actually picked: it is\
+   an 800 kB script and every raster background works without it. Until it\
+   lands, the vector entry shows plain OSM tiles. */\
+var MAPLIBRE_STATE = "idle";\
+function loadMapLibre(onReady) {\
+    if (MAPLIBRE_STATE === "ready") { onReady(); return; }\
+    if (MAPLIBRE_STATE !== "idle") return;\
+    MAPLIBRE_STATE = "loading";\
+    var css = document.createElement("link");\
+    css.rel = "stylesheet";\
+    css.href = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css";\
+    document.head.appendChild(css);\
+    var gl = document.createElement("script");\
+    gl.src = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js";\
+    gl.onerror = function() { MAPLIBRE_STATE = "failed"; };\
+    gl.onload = function() {\
+        var br = document.createElement("script");\
+        br.src = "https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.0.22/leaflet-maplibre-gl.js";\
+        br.onerror = function() { MAPLIBRE_STATE = "failed"; };\
+        br.onload = function() { MAPLIBRE_STATE = "ready"; onReady(); };\
+        document.head.appendChild(br);\
+    };\
+    document.head.appendChild(gl);\
+}\
+\
 function applyBackground(id) {\
     var e = bgEntry(id);\
     BG_CURRENT = e.id;\
-    var next = L.tileLayer(e.url, {\
-        attribution: e.attribution,\
-        maxNativeZoom: e.maxZoom,\
-        maxZoom: MAP_MAX_ZOOM,\
-        zIndex: 1\
-    }).addTo(map);\
+    var wantsVector = !!(e.vector && e.styleUrl);\
+    if (wantsVector && MAPLIBRE_STATE !== "ready") {\
+        loadMapLibre(function() { applyBackground(BG_CURRENT); });\
+    }\
+    var next;\
+    if (wantsVector && MAPLIBRE_STATE === "ready") {\
+        next = L.maplibreGL({ style: e.styleUrl, attribution: e.attribution }).addTo(map);\
+    } else {\
+        next = L.tileLayer(e.url || BASE_TILE_URL, {\
+            attribution: e.attribution,\
+            maxNativeZoom: e.maxZoom,\
+            maxZoom: MAP_MAX_ZOOM,\
+            zIndex: 1\
+        }).addTo(map);\
+    }\
     if (baseLayer) map.removeLayer(baseLayer);\
     baseLayer = next;\
     updateBaseDim();\

--- a/contents/ui/components/RadarWebEngineView.qml
+++ b/contents/ui/components/RadarWebEngineView.qml
@@ -534,6 +534,18 @@ function updateBaseDim() {\
    an 800 kB script and every raster background works without it. Until it\
    lands, the vector entry shows plain OSM tiles. */\
 var MAPLIBRE_STATE = "idle";\
+/* MapLibre needs a WebGL context. Where there is none - blacklisted GPU, a VM,\
+   software rendering off - creating the layer throws and the map is left with\
+   no background at all, so check first and stay on raster tiles instead. */\
+var WEBGL_OK = null;\
+function hasWebGL() {\
+    if (WEBGL_OK !== null) return WEBGL_OK;\
+    try {\
+        var c = document.createElement("canvas");\
+        WEBGL_OK = !!(c.getContext("webgl2") || c.getContext("webgl"));\
+    } catch (e) { WEBGL_OK = false; }\
+    return WEBGL_OK;\
+}\
 function loadMapLibre(onReady) {\
     if (MAPLIBRE_STATE === "ready") { onReady(); return; }\
     if (MAPLIBRE_STATE !== "idle") return;\
@@ -558,14 +570,17 @@ function loadMapLibre(onReady) {\
 function applyBackground(id) {\
     var e = bgEntry(id);\
     BG_CURRENT = e.id;\
-    var wantsVector = !!(e.vector && e.styleUrl);\
+    var wantsVector = !!(e.vector && e.styleUrl && hasWebGL());\
     if (wantsVector && MAPLIBRE_STATE !== "ready") {\
         loadMapLibre(function() { applyBackground(BG_CURRENT); });\
     }\
-    var next;\
+    var next = null;\
     if (wantsVector && MAPLIBRE_STATE === "ready") {\
-        next = L.maplibreGL({ style: e.styleUrl, attribution: e.attribution }).addTo(map);\
-    } else {\
+        try {\
+            next = L.maplibreGL({ style: e.styleUrl, attribution: e.attribution }).addTo(map);\
+        } catch (err) { WEBGL_OK = false; }\
+    }\
+    if (!next) {\
         next = L.tileLayer(e.url || BASE_TILE_URL, {\
             attribution: e.attribution,\
             maxNativeZoom: e.maxZoom,\

--- a/contents/ui/components/RadarWebEngineViewLibreWXR.qml
+++ b/contents/ui/components/RadarWebEngineViewLibreWXR.qml
@@ -62,8 +62,8 @@ Item {
     }
 
     // ── Base map background ──────────────────────────────────────────────
-    // "auto" keeps the theme-driven pair this map has always used (OSM in
-    // light, Carto Dark Matter in dark); any other id pins one background
+    // "auto" keeps the theme-driven pair this map uses (OSM in light,
+    // OpenFreeMap Dark in dark); any other id pins one background
     // regardless of the theme. The page re-resolves "auto" itself on theme
     // switches, so themeHint only seeds the initial load.
     readonly property string mapBackground: Plasmoid.configuration.mapBackground || "auto"
@@ -80,7 +80,7 @@ Item {
     // setTheme's "only auto follows the theme" guard in librewxr-map.html).
     // The Dark map switch is locked read-only while one is selected, since
     // toggling it would have no visible effect on the base map.
-    readonly property var pinnedBackgroundIds: ["osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "carto-positron", "carto-darkmatter"]
+    readonly property var pinnedBackgroundIds: ["osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "openfreemap-positron", "openfreemap-dark"]
     readonly property bool darkMapLocked: radarRoot.pinnedBackgroundIds.indexOf(radarRoot.mapBackground) !== -1
 
     // A manual "Dark map" toggle only sticks until the Plasma theme itself

--- a/contents/ui/components/RadarWebEngineViewLibreWXR.qml
+++ b/contents/ui/components/RadarWebEngineViewLibreWXR.qml
@@ -80,7 +80,7 @@ Item {
     // setTheme's "only auto follows the theme" guard in librewxr-map.html).
     // The Dark map switch is locked read-only while one is selected, since
     // toggling it would have no visible effect on the base map.
-    readonly property var pinnedBackgroundIds: ["osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "openfreemap-positron", "openfreemap-dark"]
+    readonly property var pinnedBackgroundIds: ["osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "openfreemap-positron", "openfreemap-liberty", "openfreemap-fiord", "openfreemap-dark"]
     readonly property bool darkMapLocked: radarRoot.pinnedBackgroundIds.indexOf(radarRoot.mapBackground) !== -1
 
     // A manual "Dark map" toggle only sticks until the Plasma theme itself

--- a/contents/ui/components/librewxr-map.html
+++ b/contents/ui/components/librewxr-map.html
@@ -578,9 +578,12 @@
       var FALLBACK_BG = {
         dark: {
           id: "auto",
-          url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+          styleUrl: "https://tiles.openfreemap.org/styles/dark",
+          vector: true,
+          // Raster stand-in used until MapLibre has loaded, and if it never does.
+          url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
           attribution:
-            '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a> | <a href="https://librewxr.net/">LibreWXR</a>',
+            '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors | Tiles by <a href="https://openfreemap.org/">OpenFreeMap</a> | <a href="https://librewxr.net/">LibreWXR</a>',
         },
         light: {
           id: "auto",
@@ -602,7 +605,7 @@
       function resolveBg(id, theme) {
         if (id === "auto") {
           var themed = bgEntry(
-            theme === "dark" ? "carto-darkmatter" : "osm-standard",
+            theme === "dark" ? "openfreemap-dark" : "osm-standard",
           );
           return themed || FALLBACK_BG[theme] || FALLBACK_BG.dark;
         }
@@ -611,19 +614,75 @@
 
       var currentBaseMap = null;
 
+      /* Vector backgrounds need MapLibre, which is only pulled in when one is
+       * actually selected: it is an 800 kB script, and every raster background
+       * works without it. A vector entry picked before the script has arrived
+       * draws its raster fallback, and setBaseMap runs again once it loads. */
+      var maplibreState = "idle"; // idle | loading | ready | failed
+
+      function loadMapLibre(onReady) {
+        if (maplibreState === "ready") return onReady();
+        if (maplibreState === "failed") return;
+        if (maplibreState === "loading") return;
+        maplibreState = "loading";
+        var css = document.createElement("link");
+        css.rel = "stylesheet";
+        css.href = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css";
+        document.head.appendChild(css);
+        var gl = document.createElement("script");
+        gl.src = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js";
+        gl.onload = function () {
+          var bridge = document.createElement("script");
+          bridge.src =
+            "https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.0.22/leaflet-maplibre-gl.js";
+          bridge.onload = function () {
+            maplibreState = "ready";
+            onReady();
+          };
+          bridge.onerror = function () {
+            maplibreState = "failed";
+          };
+          document.head.appendChild(bridge);
+        };
+        gl.onerror = function () {
+          maplibreState = "failed";
+        };
+        document.head.appendChild(gl);
+      }
+
       function setBaseMap(theme) {
         var e = resolveBg(BG_CURRENT, theme);
+        var wantsVector = !!(e.vector && e.styleUrl);
+
+        if (wantsVector && maplibreState !== "ready") {
+          loadMapLibre(function () {
+            setBaseMap(activeTheme);
+          });
+        }
+
         if (currentBaseMap) map.removeLayer(currentBaseMap);
-        // Backgrounds stop at different zoom levels; past its own maxZoom a
-        // Leaflet layer renders nothing, so upscale the deepest tiles it has
-        // instead of leaving the base map blank under the radar.
-        currentBaseMap = L.tileLayer(e.url, {
-          attribution: e.attribution,
-          maxNativeZoom: e.maxZoom || 19,
-          maxZoom: 19,
-        });
+
+        if (wantsVector && maplibreState === "ready") {
+          // MapLibre draws the style on its own WebGL canvas; Leaflet keeps it
+          // aligned, so the radar panes above are unaffected.
+          currentBaseMap = L.maplibreGL({
+            style: e.styleUrl,
+            attribution: e.attribution,
+          });
+        } else {
+          // Backgrounds stop at different zoom levels; past its own maxZoom a
+          // Leaflet layer renders nothing, so upscale the deepest tiles it has
+          // instead of leaving the base map blank under the radar.
+          currentBaseMap = L.tileLayer(e.url || FALLBACK_BG[theme].url, {
+            attribution: e.attribution,
+            maxNativeZoom: e.maxZoom || 19,
+            maxZoom: 19,
+          });
+        }
         currentBaseMap.addTo(map);
-        currentBaseMap.bringToBack();
+        // L.maplibreGL extends L.Layer, which has no bringToBack; it sits in
+        // tilePane anyway, below the satellite and radar panes.
+        if (currentBaseMap.bringToBack) currentBaseMap.bringToBack();
       }
 
       setBaseMap(activeTheme);

--- a/contents/ui/components/librewxr-map.html
+++ b/contents/ui/components/librewxr-map.html
@@ -620,6 +620,22 @@
        * draws its raster fallback, and setBaseMap runs again once it loads. */
       var maplibreState = "idle"; // idle | loading | ready | failed
 
+      /* MapLibre needs a WebGL context. Where there is none - blacklisted GPU,
+       * a VM, software rendering turned off - creating the layer throws and the
+       * map is left with no background at all, so check before asking for one
+       * and stay on raster tiles instead. */
+      var _webglOk = null;
+      function hasWebGL() {
+        if (_webglOk !== null) return _webglOk;
+        try {
+          var c = document.createElement("canvas");
+          _webglOk = !!(c.getContext("webgl2") || c.getContext("webgl"));
+        } catch (e) {
+          _webglOk = false;
+        }
+        return _webglOk;
+      }
+
       function loadMapLibre(onReady) {
         if (maplibreState === "ready") return onReady();
         if (maplibreState === "failed") return;
@@ -652,7 +668,7 @@
 
       function setBaseMap(theme) {
         var e = resolveBg(BG_CURRENT, theme);
-        var wantsVector = !!(e.vector && e.styleUrl);
+        var wantsVector = !!(e.vector && e.styleUrl && hasWebGL());
 
         if (wantsVector && maplibreState !== "ready") {
           loadMapLibre(function () {
@@ -662,14 +678,22 @@
 
         if (currentBaseMap) map.removeLayer(currentBaseMap);
 
+        currentBaseMap = null;
         if (wantsVector && maplibreState === "ready") {
           // MapLibre draws the style on its own WebGL canvas; Leaflet keeps it
           // aligned, so the radar panes above are unaffected.
-          currentBaseMap = L.maplibreGL({
-            style: e.styleUrl,
-            attribution: e.attribution,
-          });
-        } else {
+          try {
+            currentBaseMap = L.maplibreGL({
+              style: e.styleUrl,
+              attribution: e.attribution,
+            });
+          } catch (err) {
+            // Context creation can still fail past the check; never leave the
+            // map bare - fall through to the raster layer below.
+            _webglOk = false;
+          }
+        }
+        if (!currentBaseMap) {
           // Backgrounds stop at different zoom levels; past its own maxZoom a
           // Leaflet layer renders nothing, so upscale the deepest tiles it has
           // instead of leaving the base map blank under the radar.

--- a/contents/ui/providers/mapProviders.js
+++ b/contents/ui/providers/mapProviders.js
@@ -26,6 +26,11 @@
  *   - QtLocation (ConfigMapSubPage.qml) uses singleHost, since its "osm"
  *     plugin takes one fixed host and appends {z}/{x}/{y}.png itself.
  *
+ * Backgrounds come in two shapes. Raster ones carry tileUrlTemplate and go into
+ * an L.tileLayer. Vector ones carry styleUrl with vector: true and go into an
+ * L.maplibreGL layer instead — MapLibre renders them on a WebGL canvas that
+ * Leaflet keeps in sync, so the radar overlays above them are untouched.
+ *
  * All providers are free and require no API key. Attribution strings are HTML
  * because both consumers render rich text.
  *
@@ -59,17 +64,17 @@ var MAP_BACKGROUNDS = {
         maxZoom: 17,
         attribution: _OSM_LINK + ", SRTM | © <a href='https://opentopomap.org/'>OpenTopoMap</a> (CC-BY-SA)"
     },
-    "carto-positron": {
-        tileUrlTemplate: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-        singleHost: "https://a.basemaps.cartocdn.com/light_all/",
+    "openfreemap-positron": {
+        styleUrl: "https://tiles.openfreemap.org/styles/positron",
+        vector: true,
         maxZoom: 20,
-        attribution: _OSM_LINK + " © <a href='https://carto.com/attributions'>CARTO</a>"
+        attribution: _OSM_LINK + " | Tiles by <a href='https://openfreemap.org/'>OpenFreeMap</a>"
     },
-    "carto-darkmatter": {
-        tileUrlTemplate: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-        singleHost: "https://a.basemaps.cartocdn.com/dark_all/",
+    "openfreemap-dark": {
+        styleUrl: "https://tiles.openfreemap.org/styles/dark",
+        vector: true,
         maxZoom: 20,
-        attribution: _OSM_LINK + " © <a href='https://carto.com/attributions'>CARTO</a>"
+        attribution: _OSM_LINK + " | Tiles by <a href='https://openfreemap.org/'>OpenFreeMap</a>"
     }
 };
 
@@ -85,7 +90,7 @@ var DEFAULT_MAP_BACKGROUND = "osm-standard";
 var AUTO_MAP_BACKGROUND = "auto";
 
 /** Ids offered by the "Map background" picker, in display order. */
-var MAP_BACKGROUND_ORDER = ["auto", "osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "carto-positron", "carto-darkmatter"];
+var MAP_BACKGROUND_ORDER = ["auto", "osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "openfreemap-positron", "openfreemap-dark"];
 
 /**
  * Resolve a background id to its definition.
@@ -97,6 +102,11 @@ var MAP_BACKGROUND_ORDER = ["auto", "osm-standard", "osm-humanitarian", "cyclosm
  */
 function resolveMapBackground(id, themeHint) {
     if (id === AUTO_MAP_BACKGROUND)
-        return MAP_BACKGROUNDS[themeHint === "dark" ? "carto-darkmatter" : DEFAULT_MAP_BACKGROUND];
+        return MAP_BACKGROUNDS[themeHint === "dark" ? "openfreemap-dark" : DEFAULT_MAP_BACKGROUND];
     return MAP_BACKGROUNDS[id] || MAP_BACKGROUNDS[DEFAULT_MAP_BACKGROUND];
+}
+
+/** True for backgrounds that need MapLibre GL rather than a raster tile layer. */
+function isVectorBackground(p) {
+    return !!(p && p.vector && p.styleUrl);
 }

--- a/contents/ui/providers/mapProviders.js
+++ b/contents/ui/providers/mapProviders.js
@@ -70,6 +70,18 @@ var MAP_BACKGROUNDS = {
         maxZoom: 20,
         attribution: _OSM_LINK + " | Tiles by <a href='https://openfreemap.org/'>OpenFreeMap</a>"
     },
+    "openfreemap-liberty": {
+        styleUrl: "https://tiles.openfreemap.org/styles/liberty",
+        vector: true,
+        maxZoom: 20,
+        attribution: _OSM_LINK + " | Tiles by <a href='https://openfreemap.org/'>OpenFreeMap</a>"
+    },
+    "openfreemap-fiord": {
+        styleUrl: "https://tiles.openfreemap.org/styles/fiord",
+        vector: true,
+        maxZoom: 20,
+        attribution: _OSM_LINK + " | Tiles by <a href='https://openfreemap.org/'>OpenFreeMap</a>"
+    },
     "openfreemap-dark": {
         styleUrl: "https://tiles.openfreemap.org/styles/dark",
         vector: true,
@@ -90,7 +102,7 @@ var DEFAULT_MAP_BACKGROUND = "osm-standard";
 var AUTO_MAP_BACKGROUND = "auto";
 
 /** Ids offered by the "Map background" picker, in display order. */
-var MAP_BACKGROUND_ORDER = ["auto", "osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "openfreemap-positron", "openfreemap-dark"];
+var MAP_BACKGROUND_ORDER = ["auto", "osm-standard", "osm-humanitarian", "cyclosm", "opentopomap", "openfreemap-positron", "openfreemap-liberty", "openfreemap-fiord", "openfreemap-dark"];
 
 /**
  * Resolve a background id to its definition.

--- a/translate/template.pot
+++ b/translate/template.pot
@@ -2279,8 +2279,16 @@ msgstr ""
 msgid "Open-Meteo (recommended, free)"
 msgstr ""
 
-#: contents/ui/components/MapBackgroundChoices.qml:48
+#: contents/ui/components/MapBackgroundChoices.qml:50
 msgid "OpenFreeMap Dark"
+msgstr ""
+
+#: contents/ui/components/MapBackgroundChoices.qml:49
+msgid "OpenFreeMap Fiord (dark)"
+msgstr ""
+
+#: contents/ui/components/MapBackgroundChoices.qml:48
+msgid "OpenFreeMap Liberty (light)"
 msgstr ""
 
 #: contents/ui/components/MapBackgroundChoices.qml:47

--- a/translate/template.pot
+++ b/translate/template.pot
@@ -546,14 +546,6 @@ msgstr ""
 msgid "Cards height:"
 msgstr ""
 
-#: contents/ui/components/MapBackgroundChoices.qml:48
-msgid "Carto Dark Matter (dark)"
-msgstr ""
-
-#: contents/ui/components/MapBackgroundChoices.qml:47
-msgid "Carto Positron (light)"
-msgstr ""
-
 #: contents/ui/config/tabs/ConfigMiscTab.qml:227
 msgid "Celsius (°C)"
 msgstr ""
@@ -2285,6 +2277,14 @@ msgstr ""
 
 #: contents/ui/config/configGeneral.qml:377
 msgid "Open-Meteo (recommended, free)"
+msgstr ""
+
+#: contents/ui/components/MapBackgroundChoices.qml:48
+msgid "OpenFreeMap Dark"
+msgstr ""
+
+#: contents/ui/components/MapBackgroundChoices.qml:47
+msgid "OpenFreeMap Positron (light)"
 msgstr ""
 
 #: contents/ui/components/MapBackgroundChoices.qml:43


### PR DESCRIPTION
CARTO now watermarks its keyless basemaps. The tiles still come back 200, but
with "API key required" printed across them, so there is no error to catch -
the map just arrives stamped. Since mapBackground defaults to "auto", and auto
resolved to carto-darkmatter on a dark theme, this turned up for people who
never chose CARTO in the first place.

This adds OpenFreeMap next to it. OpenFreeMap needs no key and no account, sets
no quota, renders OpenStreetMap data, and ships light and dark styles - four
are wired up: Positron, Liberty, Fiord and Dark. It is the default, so a fresh
install has a working map with nothing to set up.

CARTO stays. A new setting under "Show Radar tab in widget" picks which vendor
the background list offers - OpenFreeMap, CARTO, or both - and a key field
appears as soon as CARTO is part of the choice. Anyone who wants Positron or
Dark Matter back requests a free key at carto.com/basemaps/apikey and pastes it
in. The key has to come from the user: CARTO issues one per person and their
terms rule out shipping one inside an application.

The plain OSM, HOT, CyclOSM and OpenTopoMap backgrounds belong to neither
vendor and stay listed whatever is selected.

OpenFreeMap's tiles are vector-only, so the base map now goes through MapLibre
via the maplibre-gl-leaflet bridge. MapLibre is only fetched when a vector
background is actually picked, and anything that goes wrong falls back to
raster OSM rather than an empty map: no WebGL on the machine, CDN unreachable,
or the layer refusing to build.

Tested in a QtWebEngine view against the real page: 30 background and theme
swaps leave a single GL context behind, both fallback paths hold, and the six
provider/key combinations list what they should.
