### PR TITLE
[ja_JP]: update translation for 1.7.3

### DIFF
--- a/translate/ja_JP.po
+++ b/translate/ja_JP.po
@@ -5,9 +5,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Advanced Weather Widget\n"
-"Report-Msgid-Bugs-To: https://github.com/pnedyalkov91/advanced-weather-widget/issues\n"
-"POT-Creation-Date: 2026-08-31 13:23+0300\n"
-"PO-Revision-Date: 2026-07-21 00:00+0900\n"
+"Report-Msgid-Bugs-To: https://github.com/pnedyalkov91/advanced-weather-"
+"widget/issues\n"
+"POT-Creation-Date: 2026-08-31 15:35+0200\n"
+"PO-Revision-Date: 2026-09-07 00:00+0900\n"
 "Last-Translator: Presire <presire2@gmail.com>\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
@@ -34,23 +35,23 @@ msgstr "%1 - 明日"
 
 #: contents/ui/main.qml:1806
 msgid "%1 is ending"
-msgstr ""
+msgstr "%1 はまもなく終了"
 
 #: contents/ui/main.qml:1800
 msgid "%1 is expected"
-msgstr ""
+msgstr "%1 が予想されます"
 
 #: contents/ui/main.qml:1807
 msgid "%1 is expected to end %2."
-msgstr ""
+msgstr "%1 は %2 に終了予定。"
 
 #: contents/ui/main.qml:1801
 msgid "%1 is possible %2."
-msgstr ""
+msgstr "%1 の可能性あり %2。"
 
 #: contents/ui/main.qml:1583
 msgid "%1 there will be %2 with a low of %3 and a high of %4."
-msgstr ""
+msgstr "%1 は %2、最低 %3、最高 %4。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:1103
 msgctxt "@info %1 size %2 family"
@@ -72,7 +73,8 @@ msgstr "-90 から 90（例: 42.6977）"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:902
 msgid "0 = auto (120 px per chip). Increase if values are truncated."
-msgstr "0 = 自動（チップあたり 120 px）。値が切り捨てられる場合は増やしてください。"
+msgstr ""
+"0 = 自動（チップあたり 120 px）。値が切り捨てられる場合は増やしてください。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:902
 msgid "0 = auto. Increase if items are cut off."
@@ -128,11 +130,33 @@ msgstr "<b>見出し:</b> %1"
 
 #: contents/ui/config/configGeneral.qml:929
 msgid ""
-"<b>Hybrid-GPU / NVIDIA PRIME + Wayland crash workaround</b><br/><br/>On some hybrid-GPU laptops running Wayland, the Radar tab's embedded browser view can crash the whole Plasma shell the moment it first paints, due to a driver-level conflict between the two GPUs. This option disables GPU-accelerated compositing inside that browser view to avoid it.<br/><br/>Only enable this if you're actually experiencing that crash - it costs some rendering performance on the radar map.<br/><br/><b>This needs a log out and back in to take effect</b>, since it has to be set before Plasma starts. It also applies to the whole session, so any other app that embeds a Chromium-based browser view will pick up the same setting.\n"
-"                <br/><br/>If you enable this option, the following file will be created in: ~/.config/plasma-workspace/env/advanced-weather-widget-radar-gpu-workaround.sh"
+"<b>Hybrid-GPU / NVIDIA PRIME + Wayland crash workaround</b><br/><br/>On some "
+"hybrid-GPU laptops running Wayland, the Radar tab's embedded browser view "
+"can crash the whole Plasma shell the moment it first paints, due to a driver-"
+"level conflict between the two GPUs. This option disables GPU-accelerated "
+"compositing inside that browser view to avoid it.<br/><br/>Only enable this "
+"if you're actually experiencing that crash - it costs some rendering "
+"performance on the radar map.<br/><br/><b>This needs a log out and back in "
+"to take effect</b>, since it has to be set before Plasma starts. It also "
+"applies to the whole session, so any other app that embeds a Chromium-based "
+"browser view will pick up the same setting.\n"
+"                <br/><br/>If you enable this option, the following file will "
+"be created in: ~/.config/plasma-workspace/env/advanced-weather-widget-radar-"
+"gpu-workaround.sh"
 msgstr ""
-"<b>ハイブリッド GPU / NVIDIA PRIME + Wayland クラッシュの回避策</b><br/><br/>Wayland を実行している一部のハイブリッド GPU ノート PC では、レーダータブの埋め込みブラウザビューが最初に描画された瞬間に、2 つの GPU 間のドライバレベルの競合により Plasma シェル全体がクラッシュする可能性があります。このオプションは、そのブラウザビュー内の GPU アクセラレーションによるコンポジットを無効化して回避します。<br/><br/>実際にこのクラッシュが発生している場合のみ有効にしてください - レーダーマップのレンダリング性能が若干低下します。<br/><br/><b>この設定を反映するにはログアウトして再ログインする必要があります</b>。Plasma 起動前に設定する必要があるためです。また、セッション全体に適用されるため、Chromium ベースのブラウザビューを埋め込む他のアプリにも同じ設定が適用されます。\n"
-"                <br/><br/>このオプションを有効にすると、次のファイルが作成されます: ~/.config/plasma-workspace/env/advanced-weather-widget-radar-gpu-workaround.sh"
+"<b>ハイブリッドGPU / NVIDIA PRIME + Waylandクラッシュ回避策</b><br/><br/"
+">Waylandで動作する一部のハイブリッドGPUノートPC では、レーダータブの埋め込み"
+"ブラウザビューが最初に描画される瞬間に、2つのGPU間のドライバレベルの競合によ"
+"り Plasmaシェル全体がクラッシュすることがあります。このオプションは、そのブラ"
+"ウザビュー内のGPUアクセラレーション合成を無効化してこれを回避します。<br/"
+"><br/>実際にそのクラッシュが発生している場合にのみ有効にしてください - レー"
+"ダーマップの描画パフォーマンスが多少低下します。<br/><br/><b>この設定は、一度"
+"ログアウトして再度ログインしないと有効になりません</b>。Plasmaの起動前に設定"
+"されている必要があるためです。セッション全体に適用されるため、Chromiumベース"
+"のブラウザビューを埋め込む他のアプリも同じ設定の影響を受けます。\n"
+"                <br/><br/>このオプションを有効にすると、次の場所にファイルが"
+"作成されます: ~/.config/plasma-workspace/env/advanced-weather-widget-radar-"
+"gpu-workaround.sh"
 
 #: contents/ui/main.qml:1303
 msgid "<b>Instruction:</b> %1"
@@ -149,15 +173,33 @@ msgstr "<b>深刻度:</b> %1%2"
 
 #: contents/ui/main.qml:1375
 msgid "<b>Starts:</b> %1"
-msgstr ""
+msgstr "<b>開始:</b> %1"
 
 #: contents/ui/config/configGeneral.qml:905
-msgid "<b>Why OWM layers may not match RainViewer radar</b><br/><br/>OWM precipitation/cloud layers are <b>static model tiles</b> - they show a smoothed NWP (Numerical Weather Prediction) output, not actual radar returns. They represent where the model <i>thinks</i> it is raining based on interpolation between weather stations and model runs.<br/><br/>RainViewer uses <b>real weather radar composites</b> from radar stations - actual measured reflectivity updated every 2-10 minutes. This discrepancy is expected and known."
-msgstr "<b>OWM のレイヤーが RainViewer レーダーと一致しない理由</b><br/><br/>OWM の降水・雲レイヤーは<b>静的なモデルタイル</b>であり、実際のレーダー観測ではなく、平滑化された NWP（数値予報）の出力を表示します。気象観測所とモデル実行の間の補間に基づいて、モデルが雨が降っていると<i>推定</i>している場所を表しています。<br/><br/>RainViewer はレーダー観測所からの<b>実際の気象レーダー合成画像</b>を使用し、2〜10 分ごとに更新される実際の観測反射強度を表示します。この差異は想定されており、既知の現象です。"
+msgid ""
+"<b>Why OWM layers may not match RainViewer radar</b><br/><br/>OWM "
+"precipitation/cloud layers are <b>static model tiles</b> - they show a "
+"smoothed NWP (Numerical Weather Prediction) output, not actual radar "
+"returns. They represent where the model <i>thinks</i> it is raining based on "
+"interpolation between weather stations and model runs.<br/><br/>RainViewer "
+"uses <b>real weather radar composites</b> from radar stations - actual "
+"measured reflectivity updated every 2-10 minutes. This discrepancy is "
+"expected and known."
+msgstr "<b>OWMのレイヤーがRainViewerレーダーと一致しない理"
+"由</b><br/><br/>OWMの降水・雲レイヤーは<b>静的なモデ"
+"ルタイル</b>であり、実際のレーダー観測ではなく"
+"、平滑化されたNWP（数値予報）の出力を表示しま"
+"す。気象観測所とモデル実行の間の補間に基づい"
+"て、モデルが雨が降っていると<i>推定</i>している"
+"場所を表しています。<br/><br/>RainViewerはレーダー観"
+"測所からの<b>実際の気象レーダー合成画像</b>を使"
+"用し、2〜10分ごとに更新される実際の観測反射強"
+"度を表示します。この差異は想定されており、既"
+"知の現象です。"
 
 #: contents/ui/config/configGeneral.qml:544
 msgid "AI-powered weather intelligence. API key required below."
-msgstr "AI 搭載の気象情報サービス。下に API キーが必要です。"
+msgstr "AI搭載の気象情報サービス。下にAPIキーが必要です。"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:220
 msgid "API error"
@@ -165,7 +207,7 @@ msgstr "API エラー"
 
 #: contents/ui/config/configGeneral.qml:301
 msgid "API key is empty."
-msgstr "API キーが空です。"
+msgstr "APIキーが空です。"
 
 #: contents/ui/js/airQuality.js:171
 msgid "AQHI"
@@ -180,8 +222,11 @@ msgid "Active"
 msgstr "活動中"
 
 #: contents/ui/config/configGeneral.qml:97
-msgid "Active - GPU compositing is currently disabled for the radar map in this session."
-msgstr "有効 - このセッションではレーダーマップの GPU コンポジットが現在無効化されています。"
+msgid ""
+"Active - GPU compositing is currently disabled for the radar map in this "
+"session."
+msgstr ""
+"有効 - このセッションでは、レーダーマップのGPU合成は現在無効になっています。"
 
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:393
 msgid "Adaptive (Open-Meteo)"
@@ -217,7 +262,7 @@ msgstr "空気質"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:356
 msgid "Air Quality index standard:"
-msgstr ""
+msgstr "空気質指数の基準:"
 
 #: contents/ui/TooltipContent.qml:465
 msgid "Air Quality:"
@@ -234,8 +279,11 @@ msgid "Air quality is acceptable."
 msgstr "空気質は許容範囲です。"
 
 #: contents/ui/js/airQuality.js:103
-msgid "Air quality is acceptable; there may be a risk for people unusually sensitive to air pollution."
-msgstr ""
+msgid ""
+"Air quality is acceptable; there may be a risk for people unusually "
+"sensitive to air pollution."
+msgstr "空気質は許容範囲ですが、大気汚染に通常より敏"
+"感な人には影響が出る可能性があります。"
 
 #: contents/ui/js/airQuality.js:95
 msgid "Air quality is extremely poor."
@@ -251,7 +299,8 @@ msgstr "空気質は悪いです。"
 
 #: contents/ui/js/airQuality.js:102
 msgid "Air quality is satisfactory, and air pollution poses little or no risk."
-msgstr ""
+msgstr "空気質は良好で、大気汚染によるリスクはほとん"
+"ど、または全くありません。"
 
 #: contents/ui/js/airQuality.js:90
 msgid "Air quality is satisfactory."
@@ -283,16 +332,46 @@ msgid "Alerts provider:"
 msgstr "アラートプロバイダ:"
 
 #: contents/ui/config/configGeneral.qml:1056
-msgid "Alerts provider: <a href='https://alerts.kde.org/'>FOSS Public Alert Server</a><br/><br/>KDE's FOSS Public Alert Server collects official severe-weather warnings in CAP format from agencies worldwide and matches them to your exact location. Alert notifications work the same as with the native provider."
-msgstr "アラートプロバイダ: <a href='https://alerts.kde.org/'>FOSS Public Alert Server</a><br/><br/>KDE の FOSS Public Alert Server は、世界中の機関から CAP 形式の公式な悪天候警報を収集し、ユーザの正確な位置にマッチングします。アラート通知はネイティブプロバイダと同様に機能します。"
+msgid ""
+"Alerts provider: <a href='https://alerts.kde.org/'>FOSS Public Alert Server</"
+"a><br/><br/>KDE's FOSS Public Alert Server collects official severe-weather "
+"warnings in CAP format from agencies worldwide and matches them to your "
+"exact location. Alert notifications work the same as with the native "
+"provider."
+msgstr ""
+"アラートプロバイダ: <a href='https://alerts.kde.org/'>FOSS Public Alert "
+"Server</a><br/><br/>KDEのFOSS Public Alert Serverは、世界中の機関からCAP形式"
+"の公式な悪天候警報を収集し、ユーザの正確な位置にマッチングします。アラート通"
+"知はネイティブプロバイダと同様に機能します。"
 
 #: contents/ui/config/configGeneral.qml:1047
-msgid "Alerts provider: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/>LibreWXR is a free, open-source weather API that aggregates official CAP alerts worldwide (WMO Severe Weather Information Centre, NOAA NWS, and others) and matches them to your exact location. Alert notifications work the same as with the native provider."
-msgstr "アラートプロバイダ: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/>LibreWXR は、世界中の公式 CAP アラート（WMO 悪天候情報センター、NOAA NWS など）を集約し、ユーザの正確な位置にマッチングする、無料のオープンソース気象 API です。アラート通知はネイティブプロバイダと同様に機能します。"
+msgid ""
+"Alerts provider: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/"
+">LibreWXR is a free, open-source weather API that aggregates official CAP "
+"alerts worldwide (WMO Severe Weather Information Centre, NOAA NWS, and "
+"others) and matches them to your exact location. Alert notifications work "
+"the same as with the native provider."
+msgstr ""
+"アラートプロバイダ: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/"
+">LibreWXRは、世界中の公式CAPアラート（WMO悪天候情報センター、NOAA NWSなど）を"
+"集約し、ユーザの正確な位置にマッチングする、無料のオープンソース気象APIです。"
+"アラート通知はネイティブプロバイダと同様に機能します。"
 
 #: contents/ui/config/configGeneral.qml:1038
-msgid "Alerts provider: <a href='https://www.meteoalarm.org/'>EUMETNET MeteoAlarm</a> + <a href='https://www.weather.gov/'>NOAA NWS</a><br/><br/>European locations use the official MeteoAlarm feeds (38 countries), US locations use the NOAA National Weather Service alerts API, with met.no MetAlerts as a fallback. If your weather provider delivers its own alerts (e.g. WeatherAPI.com, Pirate Weather), those are used directly."
-msgstr "アラートプロバイダ: <a href='https://www.meteoalarm.org/'>EUMETNET MeteoAlarm</a> + <a href='https://www.weather.gov/'>NOAA NWS</a><br/><br/>ヨーロッパの地域では公式 MeteoAlarm フィード（38 か国）を、米国の地域では NOAA National Weather Service アラート API を使用し、フォールバックとして met.no MetAlerts を使用します。気象プロバイダが独自のアラート（例: WeatherAPI.com、Pirate Weather）を提供している場合は、それが直接使用されます。"
+msgid ""
+"Alerts provider: <a href='https://www.meteoalarm.org/'>EUMETNET MeteoAlarm</"
+"a> + <a href='https://www.weather.gov/'>NOAA NWS</a><br/><br/>European "
+"locations use the official MeteoAlarm feeds (38 countries), US locations use "
+"the NOAA National Weather Service alerts API, with met.no MetAlerts as a "
+"fallback. If your weather provider delivers its own alerts (e.g. "
+"WeatherAPI.com, Pirate Weather), those are used directly."
+msgstr ""
+"アラートプロバイダ: <a href='https://www.meteoalarm.org/'>EUMETNET "
+"MeteoAlarm</a> + <a href='https://www.weather.gov/'>NOAA NWS</a><br/><br/>"
+"ヨーロッパの地域では公式MeteoAlarmフィード（38 か国）を、米国の地域ではNOAA "
+"National Weather ServiceアラートAPIを使用し、フォールバックとしてmet.no "
+"MetAlertsを使用します。気象プロバイダが独自のアラート（例: WeatherAPI.com、"
+"Pirate Weather）を提供している場合は、それが直接使用されます。"
 
 #: contents/ui/TooltipContent.qml:480
 msgid "Alerts:"
@@ -320,23 +399,30 @@ msgstr "標高: %1 m"
 
 #: contents/ui/config/configGeneral.qml:538
 msgid "Alternative provider. API key required below."
-msgstr "代替プロバイダ。下に API キーが必要です。"
+msgstr "代替プロバイダ。下にAPIキーが必要です。"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:464
 msgid "Altitude (%1):"
 msgstr "標高（%1）:"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:483
-msgid "Altitude is optional, but strongly recommended for accurate forecasts. MET Norway (met.no) uses it to correct temperature and pressure for elevation; leaving it at 0 for a mountain location will return sea-level values."
-msgstr "標高は省略可能ですが、正確な予報のためには強く推奨されます。MET Norway (met.no) は標高に応じて気温と気圧を補正します。山岳地帯で 0 のままにすると、海抜の値が返されます。"
+msgid ""
+"Altitude is optional, but strongly recommended for accurate forecasts. MET "
+"Norway (met.no) uses it to correct temperature and pressure for elevation; "
+"leaving it at 0 for a mountain location will return sea-level values."
+msgstr ""
+"標高は省略可能ですが、正確な予報のためには強く推奨されます。MET Norway "
+"(met.no) は標高に応じて気温と気圧を補正します。山岳地帯で0のままにすると、海"
+"抜の値が返されます。"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:610
 msgid "Altitude:"
 msgstr "標高:"
 
 #: contents/ui/config/configGeneral.qml:736
-msgid "An API key is required for %1. Weather data cannot be retrieved without it."
-msgstr "%1 には API キーが必要です。API キーがないと気象データを取得できません。"
+msgid ""
+"An API key is required for %1. Weather data cannot be retrieved without it."
+msgstr "%1 には APIキーが必要です。APIキーがないと気象データを取得できません。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:805
 msgid "Animate row scrolling"
@@ -367,8 +453,12 @@ msgid "Apply detected location"
 msgstr "検出した位置を適用"
 
 #: contents/ui/config/configLocation.qml:1380
-msgid "Are you sure? This is your last saved location. If you remove it, the widget will no longer show weather information."
-msgstr "本当によろしいですか? これは最後に保存した位置です。削除すると、ウィジェットは気象情報を表示しなくなります。"
+msgid ""
+"Are you sure? This is your last saved location. If you remove it, the widget "
+"will no longer show weather information."
+msgstr ""
+"本当によろしいですか? これは最後に保存した位置です。削除すると、ウィジェット"
+"は気象情報を表示しなくなります。"
 
 #: contents/ui/DetailsView.qml:3513
 msgid "Around midnight - "
@@ -376,7 +466,7 @@ msgstr "真夜中頃 - "
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:355
 msgid "Arrows"
-msgstr ""
+msgstr "矢印"
 
 #: contents/ui/config/configAppearance.qml:1389
 #: contents/ui/config/configAppearance.qml:1491
@@ -407,12 +497,28 @@ msgid "Auto (detect on save)"
 msgstr "自動（保存時に検出）"
 
 #: contents/ui/config/configLocation.qml:1524
-msgid "Auto-detection first asks GeoClue2, the system location service, for your current position. If system location is unavailable, the widget estimates your location from your public IP address, which is usually less precise and only updates when detection runs again."
-msgstr "自動検出では、まずシステム位置サービスである GeoClue2 に現在位置を問い合わせます。システム位置が利用できない場合、ウィジェットは公衆 IP アドレスから位置を推定します。これは通常精度が低く、検出を再実行したときにのみ更新されます。"
+msgid ""
+"Auto-detection first asks GeoClue2, the system location service, for your "
+"current position. If system location is unavailable, the widget estimates "
+"your location from your public IP address, which is usually less precise and "
+"only updates when detection runs again."
+msgstr ""
+"自動検出では、まずシステム位置サービスであるGeoClue2に現在位置を問い合わせま"
+"す。システム位置が利用できない場合、ウィジェットは公衆IPアドレスから位置を推"
+"定します。これは通常精度が低く、検出を再実行したときにのみ更新されます。"
 
 #: contents/ui/config/configLocation.qml:1485
-msgid "Auto-detection is limited without QtLocation and QtPositioning. It will fall back to IP-based detection, which may be less accurate and will not update in real time as you move. If you want to improve auto-detection accuracy, please install the required packages for your distribution. For more details, see the install guide."
-msgstr "QtLocation と QtPositioning がないと自動検出は制限されます。IP ベースの検出にフォールバックしますが、精度が低く、移動してもリアルタイムで更新されません。自動検出の精度を向上させるには、ディストリビューション用の必要なパッケージをインストールしてください。詳細はインストールガイドを参照してください。"
+msgid ""
+"Auto-detection is limited without QtLocation and QtPositioning. It will fall "
+"back to IP-based detection, which may be less accurate and will not update "
+"in real time as you move. If you want to improve auto-detection accuracy, "
+"please install the required packages for your distribution. For more "
+"details, see the install guide."
+msgstr ""
+"QtLocationとQtPositioningがないと自動検出は制限されます。IPベースの検出に"
+"フォールバックしますが、精度が低く、移動してもリアルタイムで更新されません。"
+"自動検出の精度を向上させるには、ディストリビューション用の必要なパッケージを"
+"インストールしてください。詳細はインストールガイドを参照してください。"
 
 #: contents/ui/config/configLocation.qml:753
 msgid "Auto-detection updated coordinates."
@@ -429,11 +535,15 @@ msgstr "自動"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:361
 msgid "Automatic (based on location)"
-msgstr ""
+msgstr "自動（位置に基づく）"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:385
-msgid "Automatic uses US AQI worldwide, switching to European CAQI or Canadian AQHI based on your location's country."
-msgstr ""
+msgid ""
+"Automatic uses US AQI worldwide, switching to European CAQI or Canadian AQHI "
+"based on your location's country."
+msgstr "自動では世界中で米国 AQI を使用し、位置の国に応"
+"じて欧州 CAQI またはカナダ AQHI に切り替わります"
+"。"
 
 #: contents/ui/config/configLocation.qml:1508
 msgid "Automatically detect location"
@@ -451,7 +561,7 @@ msgstr "雪崩"
 
 #: contents/ui/js/airQuality.js:123
 msgid "Avoid strenuous outdoor activities."
-msgstr ""
+msgstr "激しい屋外活動は避けてください。"
 
 #: contents/ui/config/configGeneral.qml:385
 msgid "BBC Weather (free)"
@@ -546,7 +656,7 @@ msgstr "Bz（磁場）"
 
 #: contents/ui/js/airQuality.js:172
 msgid "CAQI"
-msgstr ""
+msgstr "CAQI"
 
 #: contents/ui/config/subpages/ConfigDetailsSubPage.qml:594
 msgid "CO"
@@ -555,7 +665,7 @@ msgstr "CO"
 #: contents/ui/config/tabs/ConfigMiscTab.qml:342
 #: contents/ui/config/tabs/ConfigMiscTab.qml:373
 msgid "Canadian AQHI (1-10+)"
-msgstr ""
+msgstr "カナダ AQHI（1-10+）"
 
 #: contents/ui/config/configAppearance.qml:584
 #: contents/ui/config/configLocation.qml:1407
@@ -591,11 +701,13 @@ msgstr "摂氏（°C）"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:543
 msgid "Changes staged. Click the main Apply button to save."
-msgstr "変更がステージングされました。メインの適用ボタンをクリックして保存してください。"
+msgstr ""
+"変更がステージングされました。メインの適用ボタンをクリックして保存してくださ"
+"い。"
 
 #: contents/ui/config/configGeneral.qml:945
 msgid "Check Status"
-msgstr "状態確認"
+msgstr "状態を確認"
 
 #: contents/ui/config/configGeneral.qml:173
 #: contents/ui/config/configLocation.qml:481
@@ -609,7 +721,7 @@ msgstr "確認中…"
 
 #: contents/ui/config/configGeneral.qml:550
 msgid "Chinese weather provider with global coverage. API key required below."
-msgstr "グローバルカバレッジの中国気象プロバイダ。下に API キーが必要です。"
+msgstr "グローバルカバレッジの中国気象プロバイダ。下にAPIキーが必要です。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:999
 msgid "Choose Simple Mode Font"
@@ -666,8 +778,13 @@ msgid "Clear sky"
 msgstr "快晴"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:581
-msgid "Click \"Test across providers\" to check if the coordinates are serviceable by each supported weather provider. Providers requiring an API key that is not configured will be skipped."
-msgstr "「プロバイダ横断テスト」をクリックして、座標が各対応気象プロバイダで利用可能か確認します。API キーが必要だが設定されていないプロバイダはスキップされます。"
+msgid ""
+"Click \"Test across providers\" to check if the coordinates are serviceable "
+"by each supported weather provider. Providers requiring an API key that is "
+"not configured will be skipped."
+msgstr ""
+"「プロバイダ横断テスト」をクリックして、座標が各対応気象プロバイダで利用可能"
+"か確認します。APIキーが必要だが設定されていないプロバイダはスキップされます。"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:635
 msgid "Click on the map to select a location"
@@ -687,11 +804,15 @@ msgstr "沿岸現象"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:548
 msgid "Color by temperature:"
-msgstr "気温で色分け:"
+msgstr "気温による着色:"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:555
-msgid "Color the panel temperature with the same cold to hot scale as the forecast curve, instead of a fixed color."
-msgstr "パネルの気温を、固定色ではなく予報曲線と同じ寒色から暖色のスケールで色分けします。"
+msgid ""
+"Color the panel temperature with the same cold to hot scale as the forecast "
+"curve, instead of a fixed color."
+msgstr ""
+"固定色の代わりに、予報曲線と同じ寒色〜暖色のスケールでパネルの気温を着色しま"
+"す。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:303
 #: contents/ui/config/tabs/ConfigPanelTab.qml:312
@@ -700,7 +821,7 @@ msgstr "カラー"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:820
 msgid "Colorful (KDE color icons)"
-msgstr "カラー（KDE カラーアイコン）"
+msgstr "カラー（KDEカラーアイコン）"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:1066
 msgid "Compass in forecast:"
@@ -775,16 +896,25 @@ msgid "Connection successful! %1 key is valid."
 msgstr "接続に成功しました! %1 のキーは有効です。"
 
 #: contents/ui/js/airQuality.js:121
-msgid "Consider reducing or rescheduling strenuous outdoor activities if you experience symptoms such as coughing or throat irritation."
-msgstr ""
+msgid ""
+"Consider reducing or rescheduling strenuous outdoor activities if you "
+"experience symptoms such as coughing or throat irritation."
+msgstr "咳や喉の刺激などの症状がある場合は、激しい屋"
+"外活動を減らすか、時間をずらすことを検討して"
+"ください。"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:270
 msgid "Coordinates"
 msgstr "座標"
 
 #: contents/ui/config/configNotifications.qml:304
-msgid "Critical notifications are still shown even when Do Not Disturb is enabled, or while you're playing a game or watching a fullscreen video (if those options are enabled in System Settings → Notifications)."
-msgstr "重要な通知は、Do Not Disturb が有効でも、ゲーム中や全画面動画視聴中でも表示されます（システム設定 → 通知でそのオプションが有効な場合）。"
+msgid ""
+"Critical notifications are still shown even when Do Not Disturb is enabled, "
+"or while you're playing a game or watching a fullscreen video (if those "
+"options are enabled in System Settings → Notifications)."
+msgstr ""
+"重要な通知は、Do Not Disturbが有効でも、ゲーム中や全画面動画視聴中でも表示さ"
+"れます。（システム設定 → 通知でそのオプションが有効な場合）"
 
 #: contents/ui/config/configAppearance.qml:1466
 #: contents/ui/config/configAppearance.qml:1589
@@ -828,7 +958,7 @@ msgstr "状態別カスタムアイコン"
 msgid "Custom…"
 msgstr "カスタム…"
 
-#: contents/ui/components/MapBackgroundChoices.qml:45
+#: contents/ui/components/MapBackgroundChoices.qml:46
 msgid "CyclOSM (cycling)"
 msgstr "CyclOSM（サイクリング）"
 
@@ -838,7 +968,7 @@ msgstr "日別予報設定"
 
 #: contents/ui/config/configGeneral.qml:540
 msgid "Dark Sky-compatible API with US alerts. API key required below."
-msgstr "Dark Sky 互換 API（米国アラート対応）。下に API キーが必要です。"
+msgstr "Dark Sky 互換 API（米国アラート対応）。下にAPIキーが必要です。"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:397
 msgid "Dark map"
@@ -846,7 +976,7 @@ msgstr "ダークマップ"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:927
 msgid "Dash  –"
-msgstr ""
+msgstr "ダッシュ  –"
 
 #: contents/ui/config/configGeneral.qml:1075
 msgid "Data Refresh"
@@ -963,8 +1093,13 @@ msgid "Dew point:"
 msgstr "露点:"
 
 #: contents/ui/config/configNotifications.qml:353
-msgid "Disable a type to silence it, or give it its own repeat interval. The interval is used only when 'Repeat reminder until dismissed' is on."
-msgstr "種類を無効にすると通知を停止できます。または独自の繰り返し間隔を設定できます。この間隔は「閉じるまでリマインダーを繰り返す」がオンの場合にのみ使用されます。"
+msgid ""
+"Disable a type to silence it, or give it its own repeat interval. The "
+"interval is used only when 'Repeat reminder until dismissed' is on."
+msgstr ""
+"種類を無効にすると通知を停止できます。または独自の繰り返し間隔を設定できま"
+"す。この間隔は「閉じるまでリマインダーを繰り返す」がオンの場合にのみ使用され"
+"ます。"
 
 #: contents/ui/config/subpages/ConfigPanelSubPage.qml:488
 #: contents/ui/config/subpages/ConfigTooltipSubPage.qml:483
@@ -1033,16 +1168,23 @@ msgid "EXTREME"
 msgstr "極端"
 
 #: contents/ui/config/configGeneral.qml:778
-msgid "Each QWeather project has a unique API host. Find yours at console.qweather.com under your project settings."
-msgstr "各 QWeather プロジェクトには固有の API ホストがあります。console.qweather.com のプロジェクト設定で確認してください。"
+msgid ""
+"Each QWeather project has a unique API host. Find yours at "
+"console.qweather.com under your project settings."
+msgstr ""
+"各QWeatherプロジェクトには固有のAPIホストがあります。console.qweather.com の"
+"プロジェクト設定で確認してください。"
 
 #: contents/ui/config/configNotifications.qml:336
 msgid "Each alert is shown only once, without Dismiss and Postpone buttons."
 msgstr "各警報は「閉じる」「延期」ボタンなしで一度だけ表示されます。"
 
 #: contents/ui/config/configNotifications.qml:234
-msgid "Each notification type can be enabled independently, with its own daily time where applicable."
-msgstr "各通知タイプは個別に有効化でき、該当する場合は毎日の時刻も設定できます。"
+msgid ""
+"Each notification type can be enabled independently, with its own daily time "
+"where applicable."
+msgstr ""
+"各通知タイプは個別に有効化でき、該当する場合は毎日の時刻も設定できます。"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:386
 msgid "Edit Saved Location"
@@ -1097,12 +1239,19 @@ msgid "Enter Manually"
 msgstr "手動で入力"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:545
-msgid "Enter a location name and valid coordinates, then click the main Apply button."
+msgid ""
+"Enter a location name and valid coordinates, then click the main Apply "
+"button."
 msgstr "位置名と有効な座標を入力し、メインの適用ボタンをクリックしてください。"
 
 #: contents/ui/config/configLocation.qml:1598
-msgid "Enter exact latitude, longitude, and optional elevation for a more local forecast. You can copy coordinates from OpenStreetMap, GeoNames, or Google Maps."
-msgstr "よりローカルな予報のため、正確な緯度、経度、および任意の標高を入力してください。OpenStreetMap、GeoNames、Google Maps から座標をコピーできます。"
+msgid ""
+"Enter exact latitude, longitude, and optional elevation for a more local "
+"forecast. You can copy coordinates from OpenStreetMap, GeoNames, or Google "
+"Maps."
+msgstr ""
+"よりローカルな予報のため、正確な緯度、経度、および任意の標高を入力してくださ"
+"い。OpenStreetMap、GeoNames、Google Mapsから座標をコピーできます。"
 
 #: contents/ui/config/configLocation.qml:1185
 msgid "Enter manually"
@@ -1110,27 +1259,27 @@ msgstr "手動で入力"
 
 #: contents/ui/config/configGeneral.qml:615
 msgid "Enter your OpenWeatherMap API key"
-msgstr "OpenWeatherMap API キーを入力"
+msgstr "OpenWeatherMap APIキーを入力"
 
 #: contents/ui/config/configGeneral.qml:617
 msgid "Enter your Pirate Weather API key"
-msgstr "Pirate Weather API キーを入力"
+msgstr "Pirate Weather APIキーを入力"
 
 #: contents/ui/config/configGeneral.qml:627
 msgid "Enter your QWeather API key"
-msgstr "QWeather API キーを入力"
+msgstr "QWeather APIキーを入力"
 
 #: contents/ui/config/configGeneral.qml:623
 msgid "Enter your StormGlass API key"
-msgstr "StormGlass API キーを入力"
+msgstr "StormGlass APIキーを入力"
 
 #: contents/ui/config/configGeneral.qml:621
 msgid "Enter your Tomorrow.io API key"
-msgstr "Tomorrow.io API キーを入力"
+msgstr "Tomorrow.io APIキーを入力"
 
 #: contents/ui/config/configGeneral.qml:619
 msgid "Enter your Visual Crossing API key"
-msgstr "Visual Crossing API キーを入力"
+msgstr "Visual Crossing APIキーを入力"
 
 #: contents/ui/config/configGeneral.qml:628
 msgid "Enter your WeatherAPI.com key"
@@ -1138,7 +1287,7 @@ msgstr "WeatherAPI.com キーを入力"
 
 #: contents/ui/config/configGeneral.qml:625
 msgid "Enter your Weatherbit API key"
-msgstr "Weatherbit API キーを入力"
+msgstr "Weatherbit APIキーを入力"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:259
 msgid "Error (code %1)"
@@ -1147,15 +1296,19 @@ msgstr "エラー（コード %1）"
 #: contents/ui/config/tabs/ConfigMiscTab.qml:335
 #: contents/ui/config/tabs/ConfigMiscTab.qml:369
 msgid "European CAQI (0-100+)"
-msgstr ""
+msgstr "欧州 CAQI（0-100+）"
 
 #: contents/ui/DetailsView.qml:3511
 msgid "Evening - "
 msgstr "夕方 - "
 
 #: contents/ui/js/airQuality.js:105
-msgid "Everyone may begin to experience health effects; sensitive groups may experience more serious effects."
-msgstr ""
+msgid ""
+"Everyone may begin to experience health effects; sensitive groups may "
+"experience more serious effects."
+msgstr "誰もが健康への影響を受け始める可能性があり、"
+"敏感な集団ではより深刻な影響を受ける可能性が"
+"あります。"
 
 #: contents/ui/js/spaceWeather.js:198
 msgid "Excellent"
@@ -1306,15 +1459,16 @@ msgstr "森林火災"
 
 #: contents/ui/config/configGeneral.qml:554
 msgid "Free BBC Weather service (data from the Met Office). No API key needed."
-msgstr "Met Office のデータを使用する無料の BBC Weather サービス。API キーは不要です。"
+msgstr ""
+"Met Officeのデータを使用する無料のBBC Weatherサービス。APIキーは不要です。"
 
 #: contents/ui/config/configGeneral.qml:552
 msgid "Free Norwegian Meteorological Institute service. No API key needed."
-msgstr "ノルウェー気象研究所の無料サービス。API キーは不要です。"
+msgstr "ノルウェー気象研究所の無料サービス。APIキーは不要です。"
 
 #: contents/ui/config/configGeneral.qml:555
 msgid "Free and open-source. No API key needed. Recommended."
-msgstr "無料でオープンソース。API キーは不要です。推奨。"
+msgstr "無料でオープンソース。APIキーは不要です。（推奨）"
 
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:54
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:686
@@ -1357,8 +1511,12 @@ msgid "Future alerts"
 msgstr "将来のアラート"
 
 #: contents/ui/config/configLocation.qml:1536
-msgid "GPS / GeoClue2 unavailable (install qt6-qtlocation for best accuracy). Using IP-based detection."
-msgstr "GPS / GeoClue2 が利用できません（最高精度のため qt6-qtlocation をインストール）。IP ベースの検出を使用します。"
+msgid ""
+"GPS / GeoClue2 unavailable (install qt6-qtlocation for best accuracy). Using "
+"IP-based detection."
+msgstr ""
+"GPS / GeoClue2が利用できません（最高精度のため qt6-qtlocation をインストー"
+"ル）。IPベースの検出を使用します。"
 
 #: contents/config/config.qml:52 contents/ui/config/tabs/ConfigWidgetTab.qml:76
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:805
@@ -1367,7 +1525,7 @@ msgstr "一般"
 
 #: contents/ui/config/configLocation.qml:819
 msgid "GeoClue2 unavailable, trying system location…"
-msgstr "GeoClue2 が利用できません。システム位置を試行中…"
+msgstr "GeoClue2が利用できません。システム位置を試行中…"
 
 #: contents/ui/config/subpages/ConfigDetailsSubPage.qml:717
 #: contents/ui/DetailsView.qml:1877
@@ -1380,7 +1538,7 @@ msgstr "地磁気活動"
 
 #: contents/ui/main.qml:1926
 msgid "Geomagnetic activity is expected to be %1 (Kp %2)"
-msgstr ""
+msgstr "地磁気活動は %1（Kp %2）になると予想されます"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:173
 msgid "Glow intensity:"
@@ -1397,7 +1555,7 @@ msgstr "イネ科"
 
 #: contents/ui/js/airQuality.js:107
 msgid "Hazardous"
-msgstr ""
+msgstr "危険"
 
 #: contents/ui/DetailsView.qml:2347
 msgid "Headline"
@@ -1405,14 +1563,18 @@ msgstr "見出し"
 
 #: contents/ui/js/airQuality.js:106
 msgid "Health alert: everyone may experience more serious health effects."
-msgstr ""
+msgstr "健康警報: 誰もがより深刻な健康影響を受ける可能"
+"性があります。"
 
 #: contents/ui/js/airQuality.js:107
-msgid "Health warning of emergency conditions: everyone is more likely to be affected."
-msgstr ""
+msgid ""
+"Health warning of emergency conditions: everyone is more likely to be "
+"affected."
+msgstr "緊急事態に関する健康警報: 誰もが影響を受ける可"
+"能性が高くなります。"
 
 #: contents/ui/components/RadarWebEngineView.qml:163
-#: contents/ui/components/RadarWebEngineView.qml:840
+#: contents/ui/components/RadarWebEngineView.qml:849
 msgid "Heavy"
 msgstr "強い"
 
@@ -1468,11 +1630,11 @@ msgstr "高"
 
 #: contents/ui/js/airQuality.js:122
 msgid "High Risk"
-msgstr ""
+msgstr "高リスク"
 
 #: contents/ui/config/configGeneral.qml:548
 msgid "High precision forecast provider. API key required below."
-msgstr "高精度予報プロバイダ。下に API キーが必要です。"
+msgstr "高精度予報プロバイダ。下にAPIキーが必要です。"
 
 #: contents/ui/config/configNotifications.qml:46 contents/ui/main.qml:1029
 msgid "High temperature"
@@ -1480,7 +1642,7 @@ msgstr "高温"
 
 #: contents/ui/config/configGeneral.qml:542
 msgid "Historical and forecast data provider. API key required below."
-msgstr "過去と予報データプロバイダ。下に API キーが必要です。"
+msgstr "過去と予報データプロバイダ。下にAPIキーが必要です。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:154
 msgid "Horizontal"
@@ -1498,7 +1660,7 @@ msgstr "時間別レイアウト:"
 msgid "How often the rows scroll to reveal the next item"
 msgstr "次の項目を表示するための行スクロール間隔"
 
-#: contents/ui/components/MapBackgroundChoices.qml:44
+#: contents/ui/components/MapBackgroundChoices.qml:45
 msgid "Humanitarian (HOT)"
 msgstr "Humanitarian（HOT）"
 
@@ -1516,7 +1678,7 @@ msgstr "湿度:"
 #: contents/ui/config/configLocation.qml:938
 #: contents/ui/config/configLocation.qml:969
 msgid "IP geolocation"
-msgstr "IP 位置情報"
+msgstr "IP位置情報"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:195
 msgid "Icon and temperature"
@@ -1559,23 +1721,35 @@ msgstr "アイコン"
 
 #: contents/ui/js/airQuality.js:120
 msgid "Ideal air quality for outdoor activities."
-msgstr ""
+msgstr "屋外活動に最適な空気質です。"
 
 #: contents/ui/config/configLocation.qml:1161
-msgid "If this looks correct, apply it. Otherwise, choose your location manually."
-msgstr "正しい場合は適用してください。そうでない場合は、位置を手動で選択してください。"
+msgid ""
+"If this looks correct, apply it. Otherwise, choose your location manually."
+msgstr ""
+"正しい場合は適用してください。そうでない場合は、位置を手動で選択してくださ"
+"い。"
 
 #: contents/ui/config/configGeneral.qml:760
-msgid "If you have just registered a new OpenWeatherMap API key, it might take up to 2 hours for it to become active. Please try again later if it doesn't work immediately."
-msgstr "新しく OpenWeatherMap API キーを登録したばかりの場合、有効になるまで最大 2 時間かかることがあります。すぐに動作しない場合は、後でもう一度お試しください。"
+msgid ""
+"If you have just registered a new OpenWeatherMap API key, it might take up "
+"to 2 hours for it to become active. Please try again later if it doesn't "
+"work immediately."
+msgstr ""
+"新しくOpenWeatherMap APIキーを登録したばかりの場合、有効になるまで最大2時間か"
+"かることがあります。すぐに動作しない場合は、後でもう一度お試しください。"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:157
 msgid "Imperial (°F, mph, inHg, in)"
 msgstr "ヤード・ポンド法（°F、mph、inHg、in）"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:132
-msgid "In a vertical panel, long item labels may be truncated. Consider using \"Simple\" mode, increasing the panel width, or reducing the font size."
-msgstr "垂直パネルでは、長い項目ラベルが切り捨てられる場合があります。「シンプル」モードの使用、パネル幅の増加、またはフォントサイズの縮小を検討してください。"
+msgid ""
+"In a vertical panel, long item labels may be truncated. Consider using "
+"\"Simple\" mode, increasing the panel width, or reducing the font size."
+msgstr ""
+"垂直パネルでは、長い項目ラベルが切り捨てられる場合があります。「シンプル」"
+"モードの使用、パネル幅の増加、またはフォントサイズの縮小を検討してください。"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:314
 msgid ""
@@ -1594,16 +1768,21 @@ msgid ""
 "Install it for your distribution:\n"
 "  • Fedora / RHEL / Arch: qt6-qtlocation\n"
 "  • openSUSE: qt6-location\n"
-"  • Debian / Kubuntu / KDE Neon: qml6-module-qtlocation and qml6-module-qtpositioning\n"
+"  • Debian / Kubuntu / KDE Neon: qml6-module-qtlocation and qml6-module-"
+"qtpositioning\n"
 "\n"
-"You can still search for a location or enter coordinates manually. Note that auto-detection will continue to work using an IP fallback, but it may be less accurate and won’t update in real time as you move around."
+"You can still search for a location or enter coordinates manually. Note that "
+"auto-detection will continue to work using an IP fallback, but it may be "
+"less accurate and won’t update in real time as you move around."
 msgstr ""
 "ディストリビューション用にインストールしてください:\n"
 "  • Fedora / RHEL / Arch: qt6-qtlocation\n"
 "  • openSUSE: qt6-location\n"
-"  • Debian / Kubuntu / KDE Neon: qml6-module-qtlocation および qml6-module-qtpositioning\n"
+"  • Debian / Kubuntu / KDE Neon: qml6-module-qtlocation および qml6-module-"
+"qtpositioning\n"
 "\n"
-"位置の検索や座標の手動入力は引き続き可能です。自動検出は IP フォールバックで引き続き動作しますが、精度が低く、移動時にリアルタイムで更新されません。"
+"位置の検索や座標の手動入力は引き続き可能です。自動検出はIPフォールバックで引"
+"き続き動作しますが、精度が低く、移動時にリアルタイムで更新されません。"
 
 #: contents/ui/RadarView.qml:181
 msgid ""
@@ -1627,11 +1806,11 @@ msgstr "間隔:"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:271
 msgid "Invalid API key (HTTP %1)"
-msgstr "無効な API キー（HTTP %1）"
+msgstr "無効なAPIキー（HTTP %1）"
 
 #: contents/ui/config/configGeneral.qml:365
 msgid "Invalid API key. Please check and try again."
-msgstr "無効な API キーです。確認して再試行してください。"
+msgstr "無効なAPIキーです。確認して再試行してください。"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:264
 msgid "Invalid response"
@@ -1657,19 +1836,23 @@ msgstr "項目の順序:"
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:41
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:49
 msgid "KDE Icon Theme"
-msgstr "KDE アイコンテーマ"
+msgstr "KDEアイコンテーマ"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:50
 msgid "KDE Symbolic"
-msgstr "KDE シンボリック"
+msgstr "KDEシンボリック"
 
 #: contents/ui/config/configAppearance.qml:453
 msgid "KDE System Icons (automatic, follows weather code)"
 msgstr "KDE システムアイコン（自動、天気コードに追従）"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:567
-msgid "KDE icon themes don't fully support many item icons. You can set your own icons by clicking \"Set your own icons\"."
-msgstr "KDE アイコンテーマは多くの項目アイコンを完全にはサポートしていません。「独自のアイコンを設定」をクリックして独自のアイコンを設定できます。"
+msgid ""
+"KDE icon themes don't fully support many item icons. You can set your own "
+"icons by clicking \"Set your own icons\"."
+msgstr ""
+"KDE アイコンテーマは多くの項目アイコンを完全にはサポートしていません。「独自"
+"のアイコンを設定」をクリックして独自のアイコンを設定できます。"
 
 #: contents/ui/config/subpages/ConfigDetailsSubPage.qml:61
 #: contents/ui/config/subpages/ConfigPanelSubPage.qml:50
@@ -1710,7 +1893,7 @@ msgstr "Kp 指数 / G 予報:"
 #: contents/ui/config/tabs/ConfigPanelTab.qml:368
 #: contents/ui/config/tabs/ConfigPanelTab.qml:457
 msgid "Large"
-msgstr ""
+msgstr "大きい"
 
 #: contents/ui/main.qml:2243
 msgid "Last Quarter"
@@ -1743,8 +1926,13 @@ msgid "Layout type:"
 msgstr "レイアウトタイプ:"
 
 #: contents/ui/config/configGeneral.qml:879
-msgid "Leave this empty to use the public server. Set it to your own address if you run a self-hosted LibreWXR instance."
-msgstr ""
+msgid ""
+"Leave this empty to use the public server. Set it to your own address if you "
+"run a self-hosted LibreWXR instance."
+msgstr "空欄のままにすると公開サーバーを使用します。"
+"セルフホストの LibreWXR インスタンスを実行してい"
+"る場合は、ご自身のアドレスを設定してください"
+"。"
 
 #: contents/ui/config/configGeneral.qml:835
 #: contents/ui/config/configGeneral.qml:1014
@@ -1753,10 +1941,10 @@ msgstr "LibreWXR"
 
 #: contents/ui/config/configGeneral.qml:872
 msgid "LibreWXR server:"
-msgstr ""
+msgstr "LibreWXR サーバー:"
 
 #: contents/ui/components/RadarWebEngineView.qml:161
-#: contents/ui/components/RadarWebEngineView.qml:840
+#: contents/ui/components/RadarWebEngineView.qml:849
 msgid "Light"
 msgstr "弱い"
 
@@ -1851,8 +2039,12 @@ msgstr "位置"
 
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:513
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:92
-msgid "Location '%1' is already in your saved list. You can apply the selected location, but it will not be saved again."
-msgstr "位置 '%1' は既に保存リストにあります。選択した位置を適用できますが、再度保存されません。"
+msgid ""
+"Location '%1' is already in your saved list. You can apply the selected "
+"location, but it will not be saved again."
+msgstr ""
+"位置 '%1' は既に保存リストにあります。選択した位置を適用できますが、再度保存"
+"されません。"
 
 #: contents/ui/config/configAppearance.qml:1395
 msgid "Location Name"
@@ -1863,7 +2055,8 @@ msgid "Location auto-detected."
 msgstr "位置を自動検出しました。"
 
 #: contents/ui/config/configLocation.qml:1536
-msgid "Location detection is depending on system configuration and permissions."
+msgid ""
+"Location detection is depending on system configuration and permissions."
 msgstr "位置検出はシステム設定と権限に依存します。"
 
 #: contents/ui/config/configGeneral.qml:262
@@ -1873,8 +2066,12 @@ msgstr "位置は %1 で利用可能です。"
 
 #: contents/ui/config/configGeneral.qml:265
 #: contents/ui/config/configLocation.qml:541
-msgid "Location is not available on %1 (HTTP %2). Try a different provider or location."
-msgstr "位置は %1 で利用できません（HTTP %2）。別のプロバイダまたは位置をお試しください。"
+msgid ""
+"Location is not available on %1 (HTTP %2). Try a different provider or "
+"location."
+msgstr ""
+"位置は %1 で利用できません（HTTP %2）。別のプロバイダまたは位置をお試しくださ"
+"い。"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:270
 msgid "Location name"
@@ -1891,7 +2088,9 @@ msgstr "位置パッケージの通知"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:544
 msgid "Location staged. Click the main Apply button to save."
-msgstr "位置がステージングされました。メインの適用ボタンをクリックして保存してください。"
+msgstr ""
+"位置がステージングされました。メインの適用ボタンをクリックして保存してくださ"
+"い。"
 
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:346
 msgid "Location:"
@@ -1930,7 +2129,7 @@ msgstr "低"
 
 #: contents/ui/js/airQuality.js:120
 msgid "Low Risk"
-msgstr ""
+msgstr "低リスク"
 
 #: contents/ui/config/configNotifications.qml:47 contents/ui/main.qml:1030
 msgid "Low temperature"
@@ -1992,11 +2191,15 @@ msgstr "地図の背景"
 
 #: contents/ui/config/configGeneral.qml:546
 msgid "Marine and weather data provider. API key required below."
-msgstr "海洋・気象データプロバイダ。下に API キーが必要です。"
+msgstr "海洋・気象データプロバイダ。下に APIキーが必要です。"
 
 #: contents/ui/js/airQuality.js:104
-msgid "Members of sensitive groups may experience health effects; the general public is less likely to be affected."
-msgstr ""
+msgid ""
+"Members of sensitive groups may experience health effects; the general "
+"public is less likely to be affected."
+msgstr "敏感な集団では健康への影響が現れる可能性があ"
+"り、一般の人々が影響を受ける可能性は比較的低"
+"くなります。"
 
 #: contents/ui/config/configGeneral.qml:1010
 msgid "MeteoAlarm + NOAA NWS (Native)"
@@ -2030,7 +2233,7 @@ msgstr "弱い地磁気嵐。"
 msgid "Misc"
 msgstr "その他"
 
-#: contents/ui/components/RadarWebEngineView.qml:840
+#: contents/ui/components/RadarWebEngineView.qml:849
 msgid "Mod"
 msgstr "中"
 
@@ -2048,7 +2251,7 @@ msgstr "中程度"
 
 #: contents/ui/js/airQuality.js:121
 msgid "Moderate Risk"
-msgstr ""
+msgstr "中程度のリスク"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:682
 msgid "Moderate drizzle"
@@ -2195,21 +2398,25 @@ msgstr "複数行（高いパネル）"
 #: contents/ui/main.qml:809 contents/ui/main.qml:842 contents/ui/main.qml:855
 #: contents/ui/main.qml:863 contents/ui/main.qml:871 contents/ui/main.qml:899
 msgid "N/A"
-msgstr ""
+msgstr "N/A"
 
 #: contents/ui/config/configAppearance.qml:1445
 #: contents/ui/config/configAppearance.qml:1568
 #: contents/ui/config/configAppearance.qml:1691
 msgid "NOAA Kp index and geomagnetic activity"
-msgstr "NOAA Kp 指数および地磁気活動"
+msgstr "NOAA Kp指数および地磁気活動"
 
 #: contents/ui/config/subpages/ConfigDetailsSubPage.qml:591
 msgid "NO₂"
 msgstr "NO₂"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:410
-msgid "Need the coordinates for a place? You can look them up at <a href=\"https://www.mapcoordinates.net/\">mapcoordinates.net</a>."
-msgstr "場所の座標が必要ですか?<a href=\"https://www.mapcoordinates.net/\">mapcoordinates.net</a> で検索できます。"
+msgid ""
+"Need the coordinates for a place? You can look them up at <a href=\"https://"
+"www.mapcoordinates.net/\">mapcoordinates.net</a>."
+msgstr ""
+"場所の座標が必要ですか?<a href=\"https://www.mapcoordinates.net/"
+"\">mapcoordinates.net</a> で検索できます。"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:273
 msgid "Network error"
@@ -2269,15 +2476,19 @@ msgid "No satellite data"
 msgstr "衛星データなし"
 
 #: contents/ui/config/configLocation.qml:1627
-msgid "No saved locations. Save the current location to quickly switch between places."
-msgstr "保存された位置がありません。現在の位置を保存すると、場所をすばやく切り替えられます。"
+msgid ""
+"No saved locations. Save the current location to quickly switch between "
+"places."
+msgstr ""
+"保存された位置がありません。現在の位置を保存すると、場所をすばやく切り替えら"
+"れます。"
 
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:538
 msgid "No weather stations found for '%1'"
 msgstr "'%1' の気象観測所が見つかりません"
 
 #: contents/ui/components/RadarWebEngineView.qml:160
-#: contents/ui/components/RadarWebEngineView.qml:840
+#: contents/ui/components/RadarWebEngineView.qml:849
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:348
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:235
 #: contents/ui/js/spaceWeather.js:202 contents/ui/main.qml:998
@@ -2298,8 +2509,11 @@ msgid "Not available (HTTP %1)"
 msgstr "利用できません（HTTP %1）"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:408
-msgid "Not available: the selected base map already has a fixed light or dark style."
-msgstr "利用できません: 選択したベースマップはすでに固定のライトまたはダークスタイルです。"
+msgid ""
+"Not available: the selected base map already has a fixed light or dark style."
+msgstr ""
+"利用できません: 選択したベースマップには、固定のライトまたはダークスタイルが"
+"既に設定されています。"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:623
 msgid "Not tested"
@@ -2315,7 +2529,7 @@ msgstr "通知"
 
 #: contents/ui/config/configNotifications.qml:310
 msgid "Notify about upcoming alerts before they start"
-msgstr ""
+msgstr "発生前に今後のアラートを通知"
 
 #: contents/ui/config/configNotifications.qml:434
 msgid "Notify about upcoming rain/storms"
@@ -2327,7 +2541,7 @@ msgstr "降雪が予想される場合に通知する"
 
 #: contents/ui/config/configNotifications.qml:462
 msgid "Notify with today's UV forecast"
-msgstr "本日の UV 予報を通知"
+msgstr "本日のUV予報を通知"
 
 #: contents/ui/config/configNotifications.qml:394
 msgid "Notify with today's forecast"
@@ -2347,8 +2561,12 @@ msgid "Now: %1%2"
 msgstr "現在: %1%2"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:799
-msgid "Number of item rows visible at once. Resize the panel height in KDE settings to match."
-msgstr "一度に表示される項目の行数。KDE 設定でパネルの高さを一致するよう調整してください。"
+msgid ""
+"Number of item rows visible at once. Resize the panel height in KDE settings "
+"to match."
+msgstr ""
+"一度に表示される項目の行数。KDE設定でパネルの高さを一致するよう調整してくださ"
+"い。"
 
 #: contents/ui/config/configAppearance.qml:576
 msgid "OK"
@@ -2376,27 +2594,31 @@ msgstr "ブラウザでレーダーを開く"
 msgid "Open-Meteo (recommended, free)"
 msgstr "Open-Meteo（推奨、無料）"
 
-#: contents/ui/components/MapBackgroundChoices.qml:50
+#: contents/ui/components/MapBackgroundChoices.qml:51
 msgid "OpenFreeMap Dark"
-msgstr ""
+msgstr "OpenFreeMap Dark"
+
+#: contents/ui/components/MapBackgroundChoices.qml:50
+msgid "OpenFreeMap Fiord (dark)"
+msgstr "OpenFreeMap Fiord（ダーク）"
 
 #: contents/ui/components/MapBackgroundChoices.qml:49
-msgid "OpenFreeMap Fiord (dark)"
-msgstr ""
+msgid "OpenFreeMap Liberty (light)"
+msgstr "OpenFreeMap Liberty（ライト）"
 
 #: contents/ui/components/MapBackgroundChoices.qml:48
-msgid "OpenFreeMap Liberty (light)"
-msgstr ""
-
-#: contents/ui/components/MapBackgroundChoices.qml:47
 msgid "OpenFreeMap Positron (light)"
-msgstr ""
+msgstr "OpenFreeMap Positron（ライト）"
+
+#: contents/ui/components/MapBackgroundChoices.qml:44
+msgid "OpenStreetMap (dark)"
+msgstr "OpenStreetMap（ダーク）"
 
 #: contents/ui/components/MapBackgroundChoices.qml:43
 msgid "OpenStreetMap (standard)"
 msgstr "OpenStreetMap（標準）"
 
-#: contents/ui/components/MapBackgroundChoices.qml:46
+#: contents/ui/components/MapBackgroundChoices.qml:47
 msgid "OpenTopoMap (topographic)"
 msgstr "OpenTopoMap（地形図）"
 
@@ -2406,7 +2628,7 @@ msgstr "OpenWeatherMap（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:588
 msgid "OpenWeatherMap API Key:"
-msgstr "OpenWeatherMap API キー:"
+msgstr "OpenWeatherMap APIキー:"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:834
 msgid "Opens today's hourly forecast automatically (or the next available day)"
@@ -2431,7 +2653,7 @@ msgstr "曇り"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:379
 msgid "Overlay detected storm cells on the map"
-msgstr ""
+msgstr "検出されたストームセルを地図にオーバーレイ表示"
 
 #: contents/ui/DetailsView.qml:1251
 msgid "Ozone (O₃)"
@@ -2519,8 +2741,12 @@ msgid "Phase + upcoming rise/set"
 msgstr "月相 + 今後の出入り"
 
 #: contents/ui/config/configLocation.qml:1584
-msgid "Pick an exact spot on the map for a more local forecast, such as your neighborhood block or a specific landmark."
-msgstr "近隣の街区や特定のランドマークなど、よりローカルな予報のために地図上の正確な地点を選択してください。"
+msgid ""
+"Pick an exact spot on the map for a more local forecast, such as your "
+"neighborhood block or a specific landmark."
+msgstr ""
+"近隣の街区や特定のランドマークなど、よりローカルな予報のために地図上の正確な"
+"地点を選択してください。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:923
 msgid "Pipe  |"
@@ -2532,7 +2758,7 @@ msgstr "Pirate Weather（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:590
 msgid "Pirate Weather API Key:"
-msgstr "Pirate Weather API キー:"
+msgstr "Pirate Weather APIキー:"
 
 #: contents/ui/components/RadarWebEngineView.qml:156
 msgid "Play"
@@ -2665,12 +2891,16 @@ msgstr "プロバイダ: %1"
 #: contents/ui/config/configGeneral.qml:493
 msgid ""
 "Providers are tried in order until one succeeds:\n"
-"Open-Meteo  →  BBC Weather  →  met.no  →  Pirate Weather  →  Visual Crossing  →  Tomorrow.io  →  StormGlass  →  Weatherbit  →  QWeather  →  OpenWeatherMap  →  WeatherAPI.com\n"
+"Open-Meteo  →  BBC Weather  →  met.no  →  Pirate Weather  →  Visual "
+"Crossing  →  Tomorrow.io  →  StormGlass  →  Weatherbit  →  QWeather  →  "
+"OpenWeatherMap  →  WeatherAPI.com\n"
 "Open-Meteo is always tried first - it is free and requires no API key."
 msgstr ""
 "プロバイダは成功するまで順番に試行されます:\n"
-"Open-Meteo  →  BBC Weather  →  met.no  →  Pirate Weather  →  Visual Crossing  →  Tomorrow.io  →  StormGlass  →  Weatherbit  →  QWeather  →  OpenWeatherMap  →  WeatherAPI.com\n"
-"Open-Meteo は常に最初に試行されます - 無料で API キーが不要です。"
+"Open-Meteo  →  BBC Weather  →  met.no  →  Pirate Weather  →  Visual "
+"Crossing  →  Tomorrow.io  →  StormGlass  →  Weatherbit  →  QWeather  →  "
+"OpenWeatherMap  →  WeatherAPI.com\n"
+"Open-Meteoは常に最初に試行されます - 無料でAPIキーが不要です。"
 
 #: contents/ui/config/configNotifications.qml:272
 msgid "Purple"
@@ -2682,27 +2912,31 @@ msgstr "QWeather（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:771
 msgid "QWeather API Host:"
-msgstr "QWeather API ホスト:"
+msgstr "QWeather APIホスト:"
 
 #: contents/ui/config/configGeneral.qml:600
 msgid "QWeather API Key:"
-msgstr "QWeather API キー:"
+msgstr "QWeather APIキー:"
 
 #: contents/ui/config/configGeneral.qml:350
 msgid "QWeather error (code %1). Check your API key."
-msgstr "QWeather エラー（コード %1）。API キーを確認してください。"
+msgstr "QWeatherエラー（コード %1）。APIキーを確認してください。"
 
 #: contents/ui/ForecastView.qml:829
-msgid "QWeather provides hourly forecasts for up to 168 hours (7 days). Daily forecast is still available for this date."
-msgstr "QWeather は最大 168 時間（7 日間）の時間別予報を提供します。この日付の日別予報は引き続き利用可能です。"
+msgid ""
+"QWeather provides hourly forecasts for up to 168 hours (7 days). Daily "
+"forecast is still available for this date."
+msgstr ""
+"QWeatherは最大168時間（7日間）の時間別予報を提供します。この日付の日別予報は"
+"引き続き利用可能です。"
 
 #: contents/ui/config/configLocation.qml:1065
 msgid "QtLocation and QtPositioning are not installed"
-msgstr "QtLocation と QtPositioning がインストールされていません"
+msgstr "QtLocationとQtPositioningがインストールされていません"
 
 #: contents/ui/RadarView.qml:156
 msgid "QtWebEngine is not installed"
-msgstr "QtWebEngine がインストールされていません"
+msgstr "QtWebEngineがインストールされていません"
 
 #: contents/ui/js/spaceWeather.js:177
 msgid "Quiet"
@@ -2732,12 +2966,42 @@ msgid "Radar provider:"
 msgstr "レーダープロバイダ:"
 
 #: contents/ui/config/configGeneral.qml:859
-msgid "Radar provider: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/>LibreWXR is a free, open-source weather radar API. It combines real radar composites from NOAA, Canadian, and European sources with a global model fallback, and provides the past 2 hours of radar data plus a short nowcast. It also offers a free satellite (infrared) layer.<br/><br/>Layer mode, radar color scheme, and motion arrows are selected directly in the Radar tab. The map follows your Plasma light/dark theme automatically."
-msgstr "レーダープロバイダ: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/>LibreWXR は無料のオープンソース気象レーダー API です。NOAA、カナダ、ヨーロッパの実際のレーダー合成画像をグローバルモデルのフォールバックと組み合わせ、過去 2 時間のレーダーデータと短時間のナウキャストを提供します。無料の衛星（赤外線）レイヤーも提供しています。<br/><br/>レイヤーモード、レーダー配色、移動方向矢印はレーダータブで直接選択します。マップは Plasma のライト/ダークテーマに自動的に追従します。"
+msgid ""
+"Radar provider: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/"
+">LibreWXR is a free, open-source weather radar API. It combines real radar "
+"composites from NOAA, Canadian, and European sources with a global model "
+"fallback, and provides the past 2 hours of radar data plus a short nowcast. "
+"It also offers a free satellite (infrared) layer.<br/><br/>Layer mode, radar "
+"color scheme, and motion arrows are selected directly in the Radar tab. The "
+"map follows your Plasma light/dark theme automatically."
+msgstr ""
+"レーダープロバイダ: <a href='https://librewxr.net/'>LibreWXR</a><br/><br/"
+">LibreWXRは、無料のオープンソース気象レーダーAPIです。NOAA、カナダ、ヨーロッ"
+"パの実際のレーダー合成画像をグローバルモデルのフォールバックと組み合わせ、過"
+"去2時間のレーダーデータと短時間のナウキャストを提供します。無料の衛星（赤外"
+"線）レイヤーも提供しています。<br/><br/>レイヤーモード、レーダー配色、移動方"
+"向矢印はレーダータブで直接選択します。マップはPlasmaのライト/ダークテーマに自"
+"動的に追従します。"
 
 #: contents/ui/config/configGeneral.qml:850
-msgid "Radar provider: <a href='https://www.rainviewer.com/'>Rain Viewer</a><br/><br/>The widget uses the free RainViewer API, which provides the past 2 hours of weather radar data in 10-minute intervals. Radar forecast is not supported.<br/><br/>Rain Viewer does not guarantee the availability of radar data. They do not conclude contracts with owners of this data. The reason is that the owners can ask them to remove their data from Rain Viewer, change the format, or stop sharing the data. They are trying to keep radar data for as long as possible, but sometimes the owners just stop providing the images."
-msgstr "レーダープロバイダ: <a href='https://www.rainviewer.com/'>Rain Viewer</a><br/><br/>ウィジェットは無料の RainViewer API を使用しており、過去 2 時間の気象レーダーデータを 10 分間隔で提供します。レーダー予報には対応していません。<br/><br/>Rain Viewer はレーダーデータの可用性を保証していません。データの所有者との間で契約を結んでいません。その理由は、所有者が Rain Viewer からのデータ削除を求めたり、形式を変更したり、データの共有を停止する可能性があるためです。レーダーデータは可能な限り長く保持するよう努めていますが、所有者が画像の提供を停止することもあります。"
+msgid ""
+"Radar provider: <a href='https://www.rainviewer.com/'>Rain Viewer</a><br/"
+"><br/>The widget uses the free RainViewer API, which provides the past 2 "
+"hours of weather radar data in 10-minute intervals. Radar forecast is not "
+"supported.<br/><br/>Rain Viewer does not guarantee the availability of radar "
+"data. They do not conclude contracts with owners of this data. The reason is "
+"that the owners can ask them to remove their data from Rain Viewer, change "
+"the format, or stop sharing the data. They are trying to keep radar data for "
+"as long as possible, but sometimes the owners just stop providing the images."
+msgstr ""
+"レーダープロバイダ: <a href='https://www.rainviewer.com/'>Rain Viewer</a><br/"
+"><br/>ウィジェットは無料のRainViewer APIを使用しており、過去2時間の気象レー"
+"ダーデータを10分間隔で提供します。レーダー予報には対応していません。<br/><br/"
+">Rain Viewerはレーダーデータの可用性を保証していません。データの所有者との間"
+"で契約を結んでいません。その理由は、所有者がRain Viewerからのデータ削除を求め"
+"たり、形式を変更したり、データの共有を停止する可能性があるためです。レーダー"
+"データは可能な限り長く保持するよう努めていますが、所有者が画像の提供を停止す"
+"ることもあります。"
 
 #: contents/ui/FullView.qml:738 contents/ui/FullView.qml:740
 msgid "Radar:"
@@ -2793,8 +3057,11 @@ msgid "Red"
 msgstr "赤"
 
 #: contents/ui/js/airQuality.js:122
-msgid "Reduce or reschedule strenuous outdoor activities, especially if you experience symptoms."
-msgstr ""
+msgid ""
+"Reduce or reschedule strenuous outdoor activities, especially if you "
+"experience symptoms."
+msgstr "特に症状がある場合は、激しい屋外活動を減らす"
+"か、時間をずらしてください。"
 
 #: contents/ui/config/configLocation.qml:1539 contents/ui/FullView.qml:419
 #: contents/ui/main.qml:369
@@ -2909,7 +3176,9 @@ msgstr "保存した位置"
 
 #: contents/ui/config/configGeneral.qml:100
 msgid "Saved, but not active yet - log out and back in for it to take effect."
-msgstr "保存されましたが、まだ有効ではありません - ログアウトして再ログインすると反映されます。"
+msgstr ""
+"保存されましたが、まだ有効ではありません - 有効にするにはログアウトして再度ロ"
+"グインしてください。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:803
 msgid "Scroll animation:"
@@ -2929,8 +3198,13 @@ msgid "Search a weather station to set your location"
 msgstr "位置を設定するために気象観測所を検索"
 
 #: contents/ui/config/configLocation.qml:1576
-msgid "Search by city or place name. Results show the location name, region, and country, and are suitable for general city-level forecasts rather than exact street-level placement."
-msgstr "都市名や地名で検索。結果には位置名、地域、国が表示され、正確なストリートレベルの配置よりも一般的な都市レベルの予報に適しています。"
+msgid ""
+"Search by city or place name. Results show the location name, region, and "
+"country, and are suitable for general city-level forecasts rather than exact "
+"street-level placement."
+msgstr ""
+"都市名や地名で検索。結果には位置名、地域、国が表示され、正確なストリートレベ"
+"ルの配置よりも一般的な都市レベルの予報に適しています。"
 
 #: contents/ui/config/configLocation.qml:1569
 msgid "Search for a location or choose it on the map."
@@ -2949,8 +3223,14 @@ msgid "Secondary unit shown first (e.g. °F / °C)"
 msgstr "副単位を先に表示（例: °F / °C）"
 
 #: contents/ui/config/configNotifications.qml:320
-msgid "Sends a single, low-priority heads-up as soon as a future alert is published (e.g. \"Heat warning starts tomorrow at 11:00\"). The normal alert notification above still fires separately once it actually becomes active."
-msgstr ""
+msgid ""
+"Sends a single, low-priority heads-up as soon as a future alert is published "
+"(e.g. \"Heat warning starts tomorrow at 11:00\"). The normal alert "
+"notification above still fires separately once it actually becomes active."
+msgstr "将来のアラートが公開されるとすぐに、優先度の"
+"低いお知らせを一度だけ送ります（例:「熱波警報"
+"は明日11:00に開始」）。実際に発効した時点で、上"
+"記の通常のアラート通知が別途送られます。"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:106
 #: contents/ui/config/tabs/ConfigPanelTab.qml:912
@@ -3022,11 +3302,11 @@ msgstr "今日を表示:"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:392
 msgid "Show WMO alerts on the map"
-msgstr ""
+msgstr "WMO アラートを地図に表示"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:327
 msgid "Show air quality standards:"
-msgstr ""
+msgstr "空気質の基準を表示:"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:78
 msgid "Show both units:"
@@ -3042,7 +3322,7 @@ msgstr "表示位置:"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:363
 msgid "Show motion arrows on the map"
-msgstr ""
+msgstr "降水の移動矢印を地図に表示"
 
 #: contents/ui/components/RadarWebEngineView.qml:159
 msgid "Show my location"
@@ -3134,7 +3414,7 @@ msgstr "シンプル表示モードの設定"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:96
 msgid "Single line (all items at once)"
-msgstr "1 行（すべての項目を一度に）"
+msgstr "1行（すべての項目を一度に）"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:1155
 #: contents/ui/config/tabs/ConfigTooltipTab.qml:230
@@ -3144,7 +3424,7 @@ msgstr "サイズ:"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:218
 msgid "Skipped - API key not configured"
-msgstr "スキップ - API キーが未設定"
+msgstr "スキップ - APIキーが未設定"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:688
 msgid "Slight rain"
@@ -3205,19 +3485,19 @@ msgstr "細氷"
 
 #: contents/ui/main.qml:1835
 msgid "Snow is ending"
-msgstr ""
+msgstr "雪はまもなく終了"
 
 #: contents/ui/main.qml:1830
 msgid "Snow is expected"
-msgstr ""
+msgstr "雪が予想されます"
 
 #: contents/ui/main.qml:1836
 msgid "Snow is expected to end %1."
-msgstr ""
+msgstr "雪は %1 に終了予定。"
 
 #: contents/ui/main.qml:1831
 msgid "Snow is possible %1."
-msgstr ""
+msgstr "雪の可能性あり %1。"
 
 #: contents/ui/config/subpages/ConfigLocationSubPage.qml:60
 #: contents/ui/main.qml:2076
@@ -3254,21 +3534,21 @@ msgstr "宇宙天気オプション"
 
 #: contents/ui/config/configGeneral.qml:536
 msgid "Standard provider. API key required below."
-msgstr "標準プロバイダ。下に API キーが必要です。"
+msgstr "標準プロバイダ。下にAPIキーが必要です。"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:789
 msgid "Stats items:"
 msgstr "統計項目:"
 
 #: contents/ui/components/RadarWebEngineView.qml:164
-#: contents/ui/components/RadarWebEngineView.qml:840
+#: contents/ui/components/RadarWebEngineView.qml:849
 #: contents/ui/js/spaceWeather.js:174
 msgid "Storm"
 msgstr "嵐"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:368
 msgid "Storm cells"
-msgstr ""
+msgstr "ストームセル"
 
 #: contents/ui/config/configGeneral.qml:409
 msgid "StormGlass (Key Required)"
@@ -3276,7 +3556,7 @@ msgstr "StormGlass（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:596
 msgid "StormGlass API Key:"
-msgstr "StormGlass API キー:"
+msgstr "StormGlass APIキー:"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:955
 msgid "Strip"
@@ -3387,8 +3667,12 @@ msgid "Swap order:"
 msgstr "順序を入れ替え:"
 
 #: contents/ui/components/RadarWebEngineViewLibreWXR.qml:408
-msgid "Switch between the light and dark map style. Until first toggled, the map follows the Plasma theme."
-msgstr "ライト/ダークのマップスタイルを切り替えます。初回切替までは、Plasma テーマに追従します。"
+msgid ""
+"Switch between the light and dark map style. Until first toggled, the map "
+"follows the Plasma theme."
+msgstr ""
+"ライト/ダークのマップスタイルを切り替えます。初回切替までは、Plasmaテーマに追"
+"従します。"
 
 #: contents/ui/FullView.qml:335
 msgid "Switch location"
@@ -3417,7 +3701,7 @@ msgstr "システムトレイバッジの背景色"
 
 #: contents/ui/config/configLocation.qml:832
 msgid "System location unavailable, trying IP geolocation…"
-msgstr "システム位置が利用できません。IP 位置情報を試行中…"
+msgstr "システム位置が利用できません。IP位置情報を試行中…"
 
 #: contents/ui/config/configAppearance.qml:2009
 msgid "System tray"
@@ -3468,7 +3752,7 @@ msgstr "気温:"
 
 #: contents/ui/config/configGeneral.qml:723
 msgid "Test API Key"
-msgstr "API キーをテスト"
+msgstr "APIキーをテスト"
 
 #: contents/ui/config/subpages/ConfigLocationManualSubPage.qml:527
 msgid "Test across providers"
@@ -3488,33 +3772,51 @@ msgid "Text labels (Temperature, Wind…)"
 msgstr "テキストラベル（気温、風…）"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:1079
-msgid "Text will follow the system font and expand to fill the available space."
-msgstr "テキストはシステムフォントに従い、利用可能な領域を埋めるよう拡張されます。"
+msgid ""
+"Text will follow the system font and expand to fill the available space."
+msgstr ""
+"テキストはシステムフォントに従い、利用可能な領域を埋めるよう拡張されます。"
 
 #: contents/ui/RadarView.qml:166
-msgid "The Radar tab requires the QtWebEngine package, which is not installed on this system."
-msgstr "レーダータブには QtWebEngine パッケージが必要ですが、このシステムにはインストールされていません。"
+msgid ""
+"The Radar tab requires the QtWebEngine package, which is not installed on "
+"this system."
+msgstr ""
+"レーダータブにはQtWebEngineパッケージが必要ですが、このシステムにはインストー"
+"ルされていません。"
 
 #: contents/ui/config/configLocation.qml:371
 msgid "The auto-detected location is already in your saved list."
 msgstr "自動検出された位置は既に保存リストにあります。"
 
 #: contents/ui/config/configAppearance.qml:472
-msgid "The condition icon will automatically reflect the current weather using your KDE system icon theme. No customisation is needed."
-msgstr "天気アイコンは KDE システムアイコンテーマを使用して現在の天気を自動的に反映します。カスタマイズは不要です。"
+msgid ""
+"The condition icon will automatically reflect the current weather using your "
+"KDE system icon theme. No customisation is needed."
+msgstr ""
+"天気アイコンは、KDEシステムアイコンテーマを使用して現在の天気を自動的に反映し"
+"ます。カスタマイズは不要です。"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:885
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:998
 msgid "The geomagnetic (Kp/G) forecast is only available up to 3 days ahead"
-msgstr "地磁気（Kp / G）予報は最大 3 日先まで利用可能です"
+msgstr "地磁気（Kp / G）予報は最大3日先まで利用可能です"
 
 #: contents/ui/config/configLocation.qml:1095
-msgid "The map picker requires the QtLocation and QtPositioning packages, which are not installed on this system."
-msgstr "地図ピッカーには QtLocation と QtPositioning パッケージが必要ですが、このシステムにはインストールされていません。"
+msgid ""
+"The map picker requires the QtLocation and QtPositioning packages, which are "
+"not installed on this system."
+msgstr ""
+"地図ピッカーにはQtLocationとQtPositioningパッケージが必要ですが、このシステム"
+"にはインストールされていません。"
 
 #: contents/ui/config/configGeneral.qml:103
-msgid "The workaround script wasn't found on disk. Try toggling the option off and on again."
-msgstr "回避策スクリプトがディスクに見つかりませんでした。オプションをオフにして再度オンにしてみてください。"
+msgid ""
+"The workaround script wasn't found on disk. Try toggling the option off and "
+"on again."
+msgstr ""
+"回避策のスクリプトがディスク上に見つかりません。オプションを一度オフにしてか"
+"ら、再度オンにしてみてください。"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:736
 msgid "Theme default"
@@ -3522,8 +3824,13 @@ msgstr "テーマのデフォルト"
 
 #: contents/ui/config/configAppearance.qml:2054
 #: contents/ui/config/configAppearance.qml:2093
-msgid "These settings only apply when the widget is placed in a panel or the system tray - they have no effect on the desktop."
-msgstr ""
+msgid ""
+"These settings only apply when the widget is placed in a panel or the system "
+"tray - they have no effect on the desktop."
+msgstr "これらの設定は、ウィジェットをパネルまたはシ"
+"ステムトレイに配置した場合にのみ適用されます"
+"。デスクトップに配置した場合には効果がありま"
+"せん。"
 
 #: contents/ui/config/configLocation.qml:182
 msgid "This location is already in your saved list."
@@ -3591,8 +3898,16 @@ msgid "Timezone:"
 msgstr "タイムゾーン:"
 
 #: contents/ui/config/configGeneral.qml:897
-msgid "To unlock additional map layers (Rain, Clouds, Temperature, Wind, Pressure): disable Adaptive mode, select OpenWeatherMap as your weather provider, and enter your API key above. When you are ready, you can enable Adaptive mode again."
-msgstr "追加の地図レイヤー（雨、雲、気温、風、気圧）のロックを解除するには: アダプティブモードを無効化し、気象プロバイダとして OpenWeatherMap を選択して、上に API キーを入力してください。準備ができたら、再度アダプティブモードを有効化できます。"
+msgid ""
+"To unlock additional map layers (Rain, Clouds, Temperature, Wind, Pressure): "
+"disable Adaptive mode, select OpenWeatherMap as your weather provider, and "
+"enter your API key above. When you are ready, you can enable Adaptive mode "
+"again."
+msgstr ""
+"追加の地図レイヤー（雨、雲、気温、風、気圧）のロックを解除するには: アダプ"
+"ティブモードを無効化し、気象プロバイダとしてOpenWeatherMapを選択して、上にAPI"
+"キーを入力してください。準備ができたら、再度アダプティブモードを有効化できま"
+"す。"
 
 #: contents/ui/ForecastView.qml:497 contents/ui/main.qml:1597
 #: contents/ui/SimpleView.qml:423
@@ -3623,7 +3938,7 @@ msgstr "Tomorrow.io（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:594
 msgid "Tomorrow.io API Key:"
-msgstr "Tomorrow.io API キー:"
+msgstr "Tomorrow.io APIキー:"
 
 #: contents/ui/main.qml:1635
 msgid "Tonight"
@@ -3683,12 +3998,17 @@ msgid "Truncate (single line)"
 msgstr "切り詰め（1 行）"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:384
-msgid "Turn off all three switches above to pick a single standard here instead."
-msgstr ""
+msgid ""
+"Turn off all three switches above to pick a single standard here instead."
+msgstr "ここで単一の基準を選択するには、上の3つのスイ"
+"ッチをすべてオフにしてください。"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:348
-msgid "Turn on any combination to show them side by side instead of a single standard below."
-msgstr ""
+msgid ""
+"Turn on any combination to show them side by side instead of a single "
+"standard below."
+msgstr "組み合わせてオンにすると、下の単一の基準の代"
+"わりに並べて表示されます。"
 
 #: contents/ui/main.qml:1282
 msgctxt "Alert severity"
@@ -3698,35 +4018,35 @@ msgstr "不明"
 #: contents/ui/config/tabs/ConfigMiscTab.qml:328
 #: contents/ui/config/tabs/ConfigMiscTab.qml:365
 msgid "US AQI (0-500)"
-msgstr ""
+msgstr "米国 AQI（0-500）"
 
 #: contents/ui/js/airQuality.js:104
 msgid "USG"
-msgstr ""
+msgstr "USG"
 
 #: contents/ui/config/configAppearance.qml:1423
 #: contents/ui/config/configAppearance.qml:1546
 #: contents/ui/config/configAppearance.qml:1669 contents/ui/DetailsView.qml:325
 #: contents/ui/SimpleView.qml:265
 msgid "UV Index"
-msgstr "UV 指数"
+msgstr "UV指数"
 
 #: contents/ui/TooltipContent.qml:460
 msgid "UV Index:"
-msgstr "UV 指数:"
+msgstr "UV指数:"
 
 #: contents/ui/config/configNotifications.qml:459 contents/ui/main.qml:1884
 msgid "UV index"
-msgstr "UV 指数"
+msgstr "UV指数"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:892
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:1005
 msgid "UV index forecast:"
-msgstr "UV 指数予報:"
+msgstr "UV指数予報:"
 
 #: contents/ui/main.qml:1881
 msgid "UV index will be %1 (%2)"
-msgstr ""
+msgstr "UV指数は %1（%2）の予想"
 
 #: contents/ui/config/configAppearance.qml:1424
 #: contents/ui/config/configAppearance.qml:1547
@@ -3741,11 +4061,11 @@ msgstr "位置を検出できません。すべての方法が失敗しました
 
 #: contents/ui/js/airQuality.js:105
 msgid "Unhealthy"
-msgstr ""
+msgstr "不健康"
 
 #: contents/ui/js/airQuality.js:104
 msgid "Unhealthy for Sensitive Groups"
-msgstr ""
+msgstr "敏感な集団に不健康"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:149
 msgid "Unit preset:"
@@ -3792,7 +4112,7 @@ msgstr "今後の出入りのみ"
 
 #: contents/ui/main.qml:1385
 msgid "Upcoming: %1"
-msgstr ""
+msgstr "今後のアラート: %1"
 
 #: contents/ui/WeatherService.qml:183
 msgid "Update timed out. Tap to retry."
@@ -3823,11 +4143,11 @@ msgstr "更新中…"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:393
 msgid "Use 24-hour format:"
-msgstr "24 時間形式を使用:"
+msgstr "24時間形式を使用:"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:161
 msgid "Use KDE locale settings"
-msgstr "KDE ロケール設定を使用"
+msgstr "KDEロケール設定を使用"
 
 #: contents/ui/config/configLocation.qml:1555
 msgid "Use manual location"
@@ -3839,12 +4159,16 @@ msgstr "地域のデフォルトを使用"
 
 #: contents/ui/config/tabs/ConfigPanelTab.qml:1202
 #: contents/ui/config/tabs/ConfigTooltipTab.qml:277
-msgid "Uses KDE system icons by default. Click the button to customise each item's icon."
-msgstr "デフォルトで KDE システムアイコンを使用します。ボタンをクリックして各項目のアイコンをカスタマイズできます。"
+msgid ""
+"Uses KDE system icons by default. Click the button to customise each item's "
+"icon."
+msgstr ""
+"デフォルトでKDEシステムアイコンを使用します。ボタンをクリックして各項目のアイ"
+"コンをカスタマイズできます。"
 
 #: contents/ui/js/airQuality.js:123
 msgid "V.High"
-msgstr ""
+msgstr "非常に高"
 
 #: contents/ui/js/airQuality.js:94
 msgid "V.Poor"
@@ -3852,7 +4176,7 @@ msgstr "非常に悪い"
 
 #: contents/ui/js/airQuality.js:106
 msgid "V.Unhealthy"
-msgstr ""
+msgstr "非常に不健康"
 
 #: contents/ui/config/tabs/ConfigMiscTab.qml:55
 msgid "Values are rounded to whole numbers"
@@ -3873,7 +4197,7 @@ msgstr "非常に高い"
 
 #: contents/ui/js/airQuality.js:123
 msgid "Very High Risk"
-msgstr ""
+msgstr "非常に高いリスク"
 
 #: contents/ui/js/airQuality.js:94
 msgid "Very Poor"
@@ -3881,7 +4205,7 @@ msgstr "非常に悪い"
 
 #: contents/ui/js/airQuality.js:106
 msgid "Very Unhealthy"
-msgstr ""
+msgstr "非常に不健康"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:708
 msgid "Violent rain showers"
@@ -3912,7 +4236,7 @@ msgstr "Visual Crossing（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:592
 msgid "Visual Crossing API Key:"
-msgstr "Visual Crossing API キー:"
+msgstr "Visual Crossing APIキー:"
 
 #: contents/ui/main.qml:2245
 msgid "Waning Crescent"
@@ -3991,15 +4315,13 @@ msgid ""
 "🟣 Purple - Extreme: extraordinarily dangerous, take action immediately.\n"
 "\n"
 "Turn a level off to stop receiving notifications for alerts of that severity."
-msgstr ""
-"天気アラートの重要度レベル（低→高）:\n"
-"\n"
-"🟡 黄 - 軽微: 状況に注意してください。\n"
-"🟠 オレンジ - 中程度: 準備をしてください。\n"
-"🔴 赤 - 重大: 行動を起こしてください。\n"
-"🟣 紫 - 極端: 極めて危険です。直ちに行動を起こしてください。\n"
-"\n"
-"レベルをオフにすると、その重要度のアラート通知を受信しなくなります。"
+msgstr "天気アラートの重要度レベル（低→高）:\n\n🟡 黄 "
+"- 軽微: 状況に注意してください。\n🟠 オレンジ - "
+"中程度: 準備をしてください。\n🔴 赤 - 重大: 行動"
+"を起こしてください。\n🟣 紫 - 極端: 極めて危険"
+"です。直ちに行動を起こしてください。\n\nレベル"
+"をオフにすると、その重要度のアラート通知を受"
+"信しなくなります。"
 
 #: contents/ui/config/configGeneral.qml:393
 msgid "WeatherAPI.com (Key Required)"
@@ -4007,7 +4329,7 @@ msgstr "WeatherAPI.com（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:601
 msgid "WeatherAPI.com API Key:"
-msgstr "WeatherAPI.com API キー:"
+msgstr "WeatherAPI.com APIキー:"
 
 #: contents/ui/config/configGeneral.qml:413
 msgid "Weatherbit (Key Required)"
@@ -4015,7 +4337,7 @@ msgstr "Weatherbit（キー必須）"
 
 #: contents/ui/config/configGeneral.qml:598
 msgid "Weatherbit API Key:"
-msgstr "Weatherbit API キー:"
+msgstr "Weatherbit APIキー:"
 
 #: contents/ui/DetailsView.qml:2363
 msgid "Website"
@@ -4064,7 +4386,7 @@ msgstr "風:"
 
 #: contents/ui/config/configGeneral.qml:914
 msgid "Workaround radar map crashes on hybrid-GPU systems (EXPERIMENTAL)"
-msgstr "ハイブリッド GPU システムでレーダーマップのクラッシュを回避（実験的）"
+msgstr "ハイブリッドGPUシステムでのレーダーマップのクラッシュを回避（実験的）"
 
 #: contents/ui/config/tabs/ConfigTooltipTab.qml:72
 msgid "Wrap to next line"
@@ -4073,7 +4395,7 @@ msgstr "次の行に折り返す"
 #: contents/ui/config/subpages/ConfigDetailsSubPage.qml:722
 #: contents/ui/DetailsView.qml:2089
 msgid "X-ray Flare Class"
-msgstr "X 線フレアクラス"
+msgstr "X線フレアクラス"
 
 #: contents/ui/config/configNotifications.qml:257
 msgid "Yellow"
@@ -4089,12 +4411,20 @@ msgstr "はい、削除します"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:340
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:431
-msgid "You can see date/time format reference at: <a href=\"https://doc.qt.io/qt-6/qml-qtqml-qt.html#formatDateTime-method\">Qt documentation</a>"
-msgstr "日付 / 時刻形式のリファレンスは <a href=\"https://doc.qt.io/qt-6/qml-qtqml-qt.html#formatDateTime-method\">Qt ドキュメント</a> を参照してください"
+msgid ""
+"You can see date/time format reference at: <a href=\"https://doc.qt.io/qt-6/"
+"qml-qtqml-qt.html#formatDateTime-method\">Qt documentation</a>"
+msgstr ""
+"日付 / 時刻形式のリファレンスは <a href=\"https://doc.qt.io/qt-6/qml-qtqml-"
+"qt.html#formatDateTime-method\">Qt ドキュメント</a> を参照してください"
 
 #: contents/ui/config/tabs/ConfigWidgetTab.qml:932
-msgid "You may need to increase the widget's width to see all the selected information"
-msgstr "選択した情報をすべて表示するには、ウィジェットの幅を広げる必要がある場合があります"
+msgid ""
+"You may need to increase the widget's width to see all the selected "
+"information"
+msgstr ""
+"選択した情報をすべて表示するには、ウィジェットの幅を広げる必要がある場合があ"
+"ります"
 
 #: contents/ui/config/subpages/ConfigMapSubPage.qml:490
 msgid "Zoom in"
@@ -4164,7 +4494,7 @@ msgstr "ft"
 msgid "grains/m³"
 msgstr "grains/m³"
 
-#: contents/ui/components/RadarWebEngineView.qml:853
+#: contents/ui/components/RadarWebEngineView.qml:862
 #: contents/ui/config/tabs/ConfigMiscTab.qml:289 contents/ui/js/weather.js:536
 msgid "hPa"
 msgstr "hPa"
@@ -4179,13 +4509,13 @@ msgstr "in"
 
 #: contents/ui/main.qml:1753
 msgid "in the next few hours"
-msgstr ""
+msgstr "これから数時間で"
 
-#: contents/ui/components/RadarWebEngineView.qml:841 contents/ui/main.qml:858
+#: contents/ui/components/RadarWebEngineView.qml:850 contents/ui/main.qml:858
 msgid "in/h"
 msgstr "in/h"
 
-#: contents/ui/components/RadarWebEngineView.qml:851
+#: contents/ui/components/RadarWebEngineView.qml:860
 #: contents/ui/config/tabs/ConfigMiscTab.qml:297 contents/ui/js/weather.js:535
 msgid "inHg"
 msgstr "inHg"
@@ -4196,7 +4526,7 @@ msgstr "inHg"
 msgid "km"
 msgstr "km"
 
-#: contents/ui/components/RadarWebEngineView.qml:846
+#: contents/ui/components/RadarWebEngineView.qml:855
 #: contents/ui/config/tabs/ConfigMiscTab.qml:254 contents/ui/js/weather.js:529
 msgid "km/h"
 msgstr "km/h"
@@ -4205,7 +4535,7 @@ msgstr "km/h"
 msgid "km/s"
 msgstr "km/s"
 
-#: contents/ui/components/RadarWebEngineView.qml:847
+#: contents/ui/components/RadarWebEngineView.qml:856
 #: contents/ui/js/weather.js:528
 msgid "kn"
 msgstr "kn"
@@ -4222,7 +4552,7 @@ msgstr "低い"
 msgid "m"
 msgstr "m"
 
-#: contents/ui/components/RadarWebEngineView.qml:848
+#: contents/ui/components/RadarWebEngineView.qml:857
 #: contents/ui/config/tabs/ConfigMiscTab.qml:262 contents/ui/js/weather.js:527
 msgid "m/s"
 msgstr "m/s"
@@ -4256,11 +4586,11 @@ msgstr "分"
 msgid "mm"
 msgstr "mm"
 
-#: contents/ui/components/RadarWebEngineView.qml:841 contents/ui/main.qml:859
+#: contents/ui/components/RadarWebEngineView.qml:850 contents/ui/main.qml:859
 msgid "mm/h"
 msgstr "mm/h"
 
-#: contents/ui/components/RadarWebEngineView.qml:852
+#: contents/ui/components/RadarWebEngineView.qml:861
 #: contents/ui/config/tabs/ConfigMiscTab.qml:293 contents/ui/js/weather.js:534
 msgid "mmHg"
 msgstr "mmHg"
@@ -4269,7 +4599,7 @@ msgstr "mmHg"
 msgid "moderate"
 msgstr "中程度"
 
-#: contents/ui/components/RadarWebEngineView.qml:845
+#: contents/ui/components/RadarWebEngineView.qml:854
 #: contents/ui/config/tabs/ConfigMiscTab.qml:258 contents/ui/js/weather.js:526
 msgid "mph"
 msgstr "mph"
@@ -4368,57 +4698,3 @@ msgstr "あなたの位置"
 #: contents/ui/js/airQuality.js:283
 msgid "µg/m³"
 msgstr "µg/m³"
-
-#~ msgid "%1 ending"
-#~ msgstr "%1 終了予定"
-
-#~ msgid "%1 expected"
-#~ msgstr "%1 予想"
-
-#~ msgid "%1 expected to end %2."
-#~ msgstr "%1 は %2 に終了予定。"
-
-#~ msgid "%1 possible %2."
-#~ msgstr "%1 の可能性あり %2。"
-
-#~ msgid "Carto Dark Matter (dark)"
-#~ msgstr "Carto Dark Matter（ダーク）"
-
-#~ msgid "Carto Positron (light)"
-#~ msgstr "Carto Positron（ライト）"
-
-#~ msgid "Dash  -"
-#~ msgstr "ダッシュ  -"
-
-#~ msgid "Not supported"
-#~ msgstr "未対応"
-
-#~ msgid "Show precipitation motion arrows"
-#~ msgstr "降水の移動方向矢印を表示"
-
-#~ msgid "Snow ending"
-#~ msgstr "雪 終了予定"
-
-#~ msgid "Snow expected"
-#~ msgstr "雪 予想"
-
-#~ msgid "Snow expected to end %1."
-#~ msgstr "雪は %1 に終了予定。"
-
-#~ msgid "Snow possible %1."
-#~ msgstr "雪の可能性あり %1。"
-
-#~ msgid "Wind arrows"
-#~ msgstr "風向矢印"
-
-#~ msgid "in the next hours"
-#~ msgstr "これからの数時間で"
-
-#~ msgid "%1 will be %2 with a low of %3 and a high of %4."
-#~ msgstr "%1 は %2、最低 %3、最高 %4。"
-
-#~ msgid "Geomagnetic activity will be %1 (Kp %2)"
-#~ msgstr "地磁気活動は %1（Kp %2）になる予想"
-
-#~ msgid "UV will be %1 (%2)"
-#~ msgstr "UV は %1（%2）の予想"


### PR DESCRIPTION
## Summary
- Sync `translate/ja_JP.po` with the current `translate/template.pot`
  (POT-Creation-Date: 2026-08-31 15:35+0200)
- Translate 70 new strings: alert status messages,
  US AQI / European CAQI / Canadian AQHI standards and health advisories,
  radar map overlays (storm cells, motion arrows),
  OpenFreeMap / OSM dark backgrounds, and new settings strings
- Remove 25 obsolete entries that no longer exist in the template
- Refresh line references and header dates
  (`PO-Revision-Date: 2026-09-07`)

## Translation status
- 969 / 969 strings translated (100%)
- No fuzzy or untranslated entries

## Notes
- Existing translations are untouched - only new and renamed strings were translated,
  following the existing style
  (full-width parentheses, half-width colon, established terminology such as 位置 / 標高 / アラート)
- Renamed strings (em-dash → hyphen, e.g. `Evening — ` → `Evening - `)
  reuse the previous Japanese wording with updated punctuation